### PR TITLE
Test coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ dev = [
     "pytest-cov",
     "pytest-asyncio",
     "pre-commit",
-    "httpx"
+    "httpx",
+    "gevent"
 ]
 
 [tool.ruff.lint]
@@ -46,10 +47,4 @@ asyncio_mode = "auto"
 source = [
     "socat"
 ]
-
-[tool.coverage.report]
-# Return values are not covered by tests when using async endpoints so
-# we will just ignore them from the coverage report.
-exclude_lines = [
-    "return .*"
-]
+concurrency = ["gevent", "thread"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ dev = [
     "coverage",
     "pytest-cov",
     "pytest-asyncio",
-    "pre-commit"
+    "pre-commit",
+    "httpx"
 ]
 
 [tool.ruff.lint]
@@ -44,4 +45,11 @@ asyncio_mode = "auto"
 [tool.coverage.run]
 source = [
     "socat"
+]
+
+[tool.coverage.report]
+# Return values are not covered by tests when using async endpoints so
+# we will just ignore them from the coverage report.
+exclude_lines = [
+    "return .*"
 ]

--- a/socat/api.py
+++ b/socat/api.py
@@ -31,11 +31,37 @@ SessionDependency = Annotated[AsyncSession, Depends(get_async_session)]
 
 
 class SourceModificationRequest(BaseModel):
+    """
+    Class which defines which atributes are available to modify
+
+    Attributes
+    ----------
+    ra : float | None
+        RA of source
+    dec : float | None
+        Dec of source
+    """
+
     ra: float | None
     dec: float | None
 
 
 class BoxRequest(BaseModel):
+    """
+    Class which defines attributes of box requests
+
+    Attributes
+    ----------
+    ra_min : float
+        Minimum RA of box
+    ra_max : float
+        Maximum RA of box
+    dec_min : float
+        Minimum dec of box
+    dec_max : float
+        Maximum dec of box
+    """
+
     ra_min: float
     ra_max: float
     dec_min: float
@@ -46,6 +72,25 @@ class BoxRequest(BaseModel):
 async def create_source(
     model: SourceModificationRequest, session: SessionDependency
 ) -> ExtragalacticSource:
+    """
+    Create a new source in the catalog
+
+    Parameters
+    ----------
+    model : SourceModificationRequest
+        Object which contains all attributes of source
+    session : SessionDependencey
+        Asynchronous session to be used
+
+    Returns
+    -------
+    response : ExtragalacticSource
+        socat.database.ExtragalacticSource object which was added to the catalog.
+    Raises
+    ------
+    HTTPException
+        If the model does not contain required info or api response is malformed
+    """
     if model.ra is None or model.dec is None:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -54,7 +99,7 @@ async def create_source(
 
     try:
         response = await core.create_source(model.ra, model.dec, session=session)
-    except ValidationError as e:
+    except ValidationError as e:  # pragma: no cover
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=e.errors())
 
     return response
@@ -73,12 +118,12 @@ async def get_box(
         BoxRequest class containing ra_min,
         ra_max, dec_min, dec_max
     session : SessionDependeny
-        Session to use
+        Asynchronous session to use
 
     Returns
     -------
     response : list[ExtragalacticSource]
-        List of sources in box
+        List of socat.database.ExtragalacticSource sources in box
 
     Raises
     ------
@@ -100,6 +145,26 @@ async def get_box(
 
 @router.get("/source/{source_id}")
 async def get_source(source_id: int, session: SessionDependency) -> ExtragalacticSource:
+    """
+    Get a source by id from the database
+
+    Parameters
+    ----------
+    source_id : int
+        ID of source to querry
+    session : SessionDependency
+        Asynchronous session to use
+
+    Returns:
+    --------
+    response : ExtragalacticSource
+        socat.database.ExtragalacticSource corresponding to id
+
+    Raises
+    ------
+    HTTPException
+        If id does not correspond to any source
+    """
     try:
         response = await core.get_source(source_id, session=session)
     except ValueError as e:
@@ -112,6 +177,28 @@ async def get_source(source_id: int, session: SessionDependency) -> Extragalacti
 async def update_source(
     source_id: int, model: SourceModificationRequest, session: SessionDependency
 ) -> ExtragalacticSource:
+    """
+    Update source parameters by id
+
+    Parameters
+    ----------
+    source_id : int
+        ID of source to update
+    model : SourceModificationRequest
+        Parameters of model to modify
+    session : SessionDependency
+        Asynchronous session to use
+
+    Returns
+    -------
+    response :  ExtragalacticSource
+        socat.database.ExtragalacticSource that has been modified
+
+    Raises
+    ------
+    HTTPException
+        If id does not correspond to any source
+    """
     try:
         response = await core.update_source(
             source_id, model.ra, model.dec, session=session
@@ -124,6 +211,26 @@ async def update_source(
 
 @router.delete("/source/{source_id}")
 async def delete_source(source_id: int, session: SessionDependency) -> None:
+    """
+    Delete a source by id
+
+    Parameters
+    ----------
+    source_id : int
+        ID of source to delete
+    session : SessionDependency
+        Asynchronous session to use
+
+    Returns
+    -------
+    None
+
+
+    Raises
+    ------
+    HTTPException
+        If id does not correspond to any source
+    """
     try:
         await core.delete_source(source_id, session=session)
     except ValueError as e:

--- a/socat/api.py
+++ b/socat/api.py
@@ -10,17 +10,20 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 import socat.core as core
 
-from .database import ExtragalacticSource, async_engine, get_async_session
+from .database import ExtragalacticSource, async_engine, get_async_session, ALL_TABLES
 
 
-async def lifetime(f: FastAPI):
+async def lifespan(f: FastAPI):
     # Use SQLModel to create the tables.
-    for table in core.ALL_TABLES:
-        await table.metadata.create_all(async_engine)
+    print("Creating tables")
+    for table in ALL_TABLES:
+        print("Creating table", table)
+        async with async_engine.begin() as conn:
+            await conn.run_sync(table.metadata.create_all)
     yield
 
 
-app = FastAPI(lifetime=lifetime)
+app = FastAPI(lifespan=lifespan)
 
 router = APIRouter(prefix="/api/v1")
 

--- a/socat/api.py
+++ b/socat/api.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 import socat.core as core
 
-from .database import ExtragalacticSource, async_engine, get_async_session, ALL_TABLES
+from .database import ALL_TABLES, ExtragalacticSource, async_engine, get_async_session
 
 
 async def lifespan(f: FastAPI):
@@ -80,17 +80,16 @@ async def get_box(
     response : list[ExtragalacticSource]
         List of sources in box
 
-    Raises:
+    Raises
     ------
-    HTTPException :
+    HTTPException
         If unphysical box bounds
     """
-    #    TODO: This raises DOC501 from ruff despite being in the docstring
-    #    if box.ra_min > box.ra_max or box.dec_min > box.dec_max:
-    #        raise HTTPException(
-    #            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-    #            detail="RA/Dec min must be <= max",
-    #        )
+    if box.ra_min > box.ra_max or box.dec_min > box.dec_max:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="RA/Dec min must be <= max",
+        )
 
     response = await core.get_box(
         box.ra_min, box.ra_max, box.dec_min, box.dec_max, session=session

--- a/socat/api.py
+++ b/socat/api.py
@@ -76,7 +76,19 @@ async def get_box(
     -------
     response : list[ExtragalacticSource]
         List of sources in box
+
+    Raises:
+    ------
+    HTTPException :
+        If unphysical box bounds
     """
+    #    TODO: This raises DOC501 from ruff despite being in the docstring
+    #    if box.ra_min > box.ra_max or box.dec_min > box.dec_max:
+    #        raise HTTPException(
+    #            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+    #            detail="RA/Dec min must be <= max",
+    #        )
+
     response = await core.get_box(
         box.ra_min, box.ra_max, box.dec_min, box.dec_max, session=session
     )

--- a/socat/client/mock.py
+++ b/socat/client/mock.py
@@ -8,14 +8,56 @@ from .core import ClientBase
 
 
 class Client(ClientBase):
+    """
+    Mock client for testing
+
+    Attributes
+    ----------
+    catalog : dict[int, ExtragalacticSource]
+        Dictionary of Extragalactic sources replciating a catalog
+    n : int
+        Number of entries in catalog
+
+    Methods
+    -------
+    create(self, *, ra: float, dec: float)
+        Create a source and add it to the catalog
+    get_box(self, *, ra_min: float, ra_max: float, dec_min: float, dec_max: float)
+        Get sources within box
+    get_source(self, *, id: int)
+        Get a source by id
+    update_source(self, *, id: int, ra: float | None = None, dec: float | None = None)
+        Update source by id
+    delete_source(self, *, id: int)
+        Delete source by id
+    """
+
     catalog: dict[int, ExtragalacticSource]
     n: int
 
     def __init__(self):
+        """
+        Initialize an empty catalog
+        """
         self.catalog = {}
         self.n = 0
 
     def create(self, *, ra: float, dec: float) -> ExtragalacticSource:
+        """
+        Create a new source and add it to the catalog.
+
+        Parameters
+        ----------
+        ra : float
+            RA of source
+        dec : float
+            Dec of source
+
+        Returns
+        -------
+        source : ExtragalacticSource
+            Extragalactic Source that was added
+        """
         source = ExtragalacticSource(id=self.n, ra=ra, dec=dec)
         self.catalog[self.n] = source
         self.n += 1
@@ -25,6 +67,27 @@ class Client(ClientBase):
     def get_box(
         self, *, ra_min: float, ra_max: float, dec_min: float, dec_max: float
     ) -> ExtragalacticSource:
+        """
+        Get sources within a box.
+
+        Parameters
+        ----------
+        ra_min : float
+            Min ra of box
+        ra_max : float
+            Max ra of box
+        dec_min : float
+            Min dec of box
+        dec_max : float
+            Max dec of box
+        session : AsyncSession
+            Asynchronous session to use
+
+        Returns
+        -------
+        list(sources) : list[ExtragalacticSource]
+            List of sources in box
+        """
         sources = filter(
             lambda x: (ra_min <= x.ra <= ra_max) and (dec_min <= x.dec <= dec_max),
             self.catalog.values(),
@@ -33,11 +96,44 @@ class Client(ClientBase):
         return list(sources)
 
     def get_source(self, *, id: int) -> ExtragalacticSource | None:
+        """
+        Get source by id
+
+        Parameters
+        ----------
+
+        id : int
+            ID of source of interest
+        session : AsyncSession
+            Asynchronous session to use
+
+        Returns
+        -------
+        self.catalog.get(id, None) : ExtragalacticSource
+            Source corresponding to id.
+        """
         return self.catalog.get(id, None)
 
     def update_source(
         self, *, id: int, ra: float | None = None, dec: float | None = None
     ) -> ExtragalacticSource | None:
+        """
+        Update a source by id
+
+        Parameters
+        ----------
+        ra : float
+            RA of source
+        dec : float
+            Dec of source
+        session : AsyncSession
+            Asynchronous session to use
+
+        Returns
+        -------
+        new : ExtragalacticSource
+            Source that has been updated
+        """
         current = self.get_source(id=id)
 
         if current is None:
@@ -54,4 +150,16 @@ class Client(ClientBase):
         return new
 
     def delete_source(self, *, id: int):
+        """
+        Delete source by id
+
+        Parameters
+        ----------
+        id : int
+            ID of source to be deleted
+
+        Returns
+        -------
+        None
+        """
         self.catalog.pop(id, None)

--- a/socat/core.py
+++ b/socat/core.py
@@ -126,7 +126,7 @@ async def update_source(
     Returns
     -------
     source.to_mode() : ExtragalacticSource
-        Source that has been created
+        Source that has been updated
 
     Raises
     ------

--- a/socat/core.py
+++ b/socat/core.py
@@ -13,6 +13,20 @@ async def create_source(
 ) -> ExtragalacticSource:
     """
     Create a new source in the database.
+
+    Parameters
+    ----------
+    ra : float
+        RA of source
+    dec : float
+        Dec of source
+    session : AsyncSession
+        Asynchronous session to use
+
+    Returns
+    -------
+    source.to_mode() : ExtragalacticSource
+        Source that has been created
     """
     source = ExtragalacticSourceTable(ra=ra, dec=dec)
 
@@ -26,6 +40,18 @@ async def create_source(
 async def get_source(source_id: int, session: AsyncSession) -> ExtragalacticSource:
     """
     Get a source from the database.
+
+    Parameters
+    ----------
+    id : int
+        ID of source of interest
+    session : AsyncSession
+        Asynchronous session to use
+
+    Returns
+    -------
+    source.to_mode() : ExtragalacticSource
+        Source that has been created
 
     Raises
     ------
@@ -60,12 +86,12 @@ async def get_box(
         Min dec of box
     dec_max : float
         Max dec of box
-    session : SessionDependency
-        SQAlchemy session
+    session : AsyncSession
+        Asynchronous session to use
 
     Returns
     -------
-    response : list[ExtragalacticSource]
+    source_list : list[ExtragalacticSource]
         List of sources in box
     """
     sources = await session.execute(
@@ -87,6 +113,20 @@ async def update_source(
 ) -> ExtragalacticSource:
     """
     Update a source in the database.
+
+    Parameters
+    ----------
+    ra : float
+        RA of source
+    dec : float
+        Dec of source
+    session : AsyncSession
+        Asynchronous session to use
+
+    Returns
+    -------
+    source.to_mode() : ExtragalacticSource
+        Source that has been created
 
     Raises
     ------
@@ -111,6 +151,17 @@ async def update_source(
 async def delete_source(source_id: int, session: AsyncSession) -> None:
     """
     Delete a source from the database.
+
+    Parameters
+    ----------
+    id : int
+        ID of source to delete
+    session : AsyncSession
+        Asynchronous session to use
+
+    Returns
+    -------
+    None
 
     Raises
     ------

--- a/socat/database.py
+++ b/socat/database.py
@@ -20,7 +20,7 @@ class ExtragalacticSource(BaseModel):
     dec: float = PydanticField(ge=-90.0, le=90.0)
 
     def __repr__(self):
-        return f"ExtragalacticSource(id={self.id}, ra={self.ra}, dec={self.dec})"
+        return f"ExtragalacticSource(id={self.id}, ra={self.ra}, dec={self.dec})"  # pragma: no cover
 
 
 class ExtragalacticSourceTable(ExtragalacticSource, SQLModel, table=True):

--- a/socat/database.py
+++ b/socat/database.py
@@ -13,6 +13,15 @@ from .settings import settings
 class ExtragalacticSource(BaseModel):
     """
     An extragalactic (i.e. fixed RA, Dec) source.
+
+    Attributes
+    ----------
+    id : int
+        Unique source identifier. Internal to SO
+    ra : float
+        RA of source in degress (-180 to 180)
+    dec : float
+        Dec of source in degrees
     """
 
     id: int
@@ -28,6 +37,11 @@ class ExtragalacticSourceTable(ExtragalacticSource, SQLModel, table=True):
     An extragalactic (i.e. fixed RA, Dec) source. This is the table model
     providing SQLModel functionality. You can export a base model, for example
     for responding to a query with using the `to_model` method.
+
+    Attributes
+    ----------
+    id : int
+        Unique source identifiers. Internal to SO
     """
 
     __tablename__ = "extragalactic_sources"
@@ -35,6 +49,14 @@ class ExtragalacticSourceTable(ExtragalacticSource, SQLModel, table=True):
     id: int = Field(primary_key=True)
 
     def to_model(self) -> ExtragalacticSource:
+        """
+        Return an Extragalactic source from table.
+
+        Returns
+        -------
+        ExtragalaticSource : ExtragalacticSource
+            Source corresponding to this id.
+        """
         return ExtragalacticSource(id=self.id, ra=self.ra, dec=self.dec)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
+import pytest
 import pytest_asyncio
+from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 
@@ -41,3 +43,13 @@ async def database_async_sesionmaker(tmp_path_factory):
 
     # Clean up the database (don't do this in case we want to inspect)
     # database_path.unlink()
+
+
+@pytest.fixture(scope="session")
+def client():
+    """
+    Create a test client for the FastAPI app.
+    """
+    from socat.api import app
+
+    yield TestClient(app)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,3 +63,13 @@ def client(tmp_path_factory):
     from socat.api import app
 
     yield TestClient(app)
+
+
+@pytest.fixture(scope="session")
+def mock_client(tmp_path_factory):
+    """
+    Create a test mock database client for mock test.
+    """
+    from socat.client import mock
+
+    yield mock.Client()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
+import os
+
 import pytest
 import pytest_asyncio
-import os
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 import pytest_asyncio
+import os
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
@@ -46,10 +47,18 @@ async def database_async_sesionmaker(tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
-def client():
+def client(tmp_path_factory):
     """
     Create a test client for the FastAPI app.
     """
+    tmp_path = tmp_path_factory.mktemp("socat")
+    # Create a temporary SQLite database for testing.
+    database_path = tmp_path / "test.db"
+
+    run_migration(database_path)
+
+    os.environ["socat_model_database_name"] = str(database_path)
+
     from socat.api import app
 
     yield TestClient(app)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -84,9 +84,6 @@ def test_update(client):
 
 
 def test_bad_id(client):
-    # response = client.put("api/v1/source/new", json={"ra": None})
-    # assert response.status_code == 422
-
     with pytest.raises(HTTPStatusError):
         response = client.put("api/v1/source/new", json={"ra": None})
         response.raise_for_status()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -84,17 +84,29 @@ def test_update(client):
 
 
 def test_bad_id(client):
-    response = client.put("api/v1/source/new", json={"ra": None})
-    assert response.status_code == 422
+    # response = client.put("api/v1/source/new", json={"ra": None})
+    # assert response.status_code == 422
+
+    with pytest.raises(HTTPStatusError):
+        response = client.put("api/v1/source/new", json={"ra": None})
+        response.raise_for_status()
 
     with pytest.raises(HTTPStatusError):
         response = client.get("api/v1/source/{}".format(999999))
         response.raise_for_status()
 
+    with pytest.raises(HTTPStatusError):
+        response = client.post(
+            "api/v1/source/{}".format(999999), json={"ra": None, "dec": None}
+        )
+        response.raise_for_status()
+
+    with pytest.raises(HTTPStatusError):
+        response = client.delete("api/v1/source/{}".format(999999))
+        response.raise_for_status()
+
+    # TODO: should move to a different func
     response = client.post(
         "api/v1/source/box",
         json={"ra_min": 1, "ra_max": 0, "dec_min": 1, "dec_max": 0},
     )
-    # assert response.status_code == 422
-
-    # with pytest.raises(ValidationError):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,7 @@
+import pytest
+from fastapi import HTTPException
+
+
 def test_add_and_retrieve(client):
     response = client.put("api/v1/source/new", json={"ra": 0.0, "dec": 0.0})
 
@@ -80,7 +84,16 @@ def test_update(client):
 
 
 def test_bad_id(client):
-    response = client.put("api/v1/source/new", json={"bad": "json"})
+    response = client.put("api/v1/source/new", json={"ra": None})
+    assert response.status_code == 422
+
+    with pytest.raises(HTTPException):
+        response = client.get("api/v1/source/{}".format(999999))
+
+    response = client.post(
+        "api/v1/source/box",
+        json={"ra_min": 1, "ra_max": 0, "dec_min": 1, "dec_max": 0},
+    )
     assert response.status_code == 422
 
     # with pytest.raises(ValidationError):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,5 @@
 import pytest
-from fastapi import HTTPException
+from httpx import HTTPStatusError
 
 
 def test_add_and_retrieve(client):
@@ -87,13 +87,14 @@ def test_bad_id(client):
     response = client.put("api/v1/source/new", json={"ra": None})
     assert response.status_code == 422
 
-    with pytest.raises(HTTPException):
+    with pytest.raises(HTTPStatusError):
         response = client.get("api/v1/source/{}".format(999999))
+        response.raise_for_status()
 
     response = client.post(
         "api/v1/source/box",
         json={"ra_min": 1, "ra_max": 0, "dec_min": 1, "dec_max": 0},
     )
-    assert response.status_code == 422
+    # assert response.status_code == 422
 
     # with pytest.raises(ValidationError):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,86 @@
+def test_add_and_retrieve(client):
+    response = client.put("api/v1/source/new", json={"ra": 0.0, "dec": 0.0})
+
+    id = response.json()["id"]
+    assert response.status_code == 200
+
+    response = client.get("api/v1/source/{}".format(id))
+
+    assert response.status_code == 200
+    assert response.json()["ra"] == 0.0
+    assert response.json()["dec"] == 0.0
+
+    response = client.delete("api/v1/source/{}".format(id))
+
+    assert response.status_code == 200
+
+    response = client.get("api/v1/source/{}".format(id))
+
+    assert (
+        response.status_code == 404
+    )  # ID should be deleted, make sure we don't find it again
+
+
+def test_get_box(client):
+    response = client.put("api/v1/source/new", json={"ra": 0.0, "dec": 0.0})
+    id1 = response.json()["id"]
+    response = client.put("api/v1/source/new", json={"ra": 1.0, "dec": 1.0})
+    id2 = response.json()["id"]
+
+    # Check we recover both sources
+    response = client.post(
+        "api/v1/source/box",
+        json={"ra_min": -1, "ra_max": 1, "dec_min": -1, "dec_max": 1},
+    )
+
+    assert response.status_code == 200
+
+    id_list = []
+    for resp in response.json():
+        id_list.append(resp["id"])
+
+    assert id1 in id_list
+    assert id2 in id_list
+
+    # Check we don't recover second source
+    response = client.post(
+        "api/v1/source/box",
+        json={"ra_min": -1, "ra_max": 0, "dec_min": -1, "dec_max": 0},
+    )
+
+    assert response.status_code == 200
+
+    id_list = []
+    for resp in response.json():
+        id_list.append(resp["id"])
+
+    assert id1 in id_list
+    assert id2 not in id_list
+
+    for id in id_list:
+        response = client.delete("api/v1/source/{}".format(id))
+        assert response.status_code == 200
+
+
+def test_update(client):
+    response = client.put("api/v1/source/new", json={"ra": 0.0, "dec": 0.0})
+
+    id = response.json()["id"]
+    assert response.status_code == 200
+
+    response = client.post("api/v1/source/{}".format(id), json={"ra": 1.0, "dec": 1.0})
+
+    assert response.status_code == 200
+    assert response.json()["id"] == id
+    assert response.json()["ra"] == 1.0
+    assert response.json()["dec"] == 1.0
+
+    response = client.delete("api/v1/source/{}".format(id))
+    assert response.status_code == 200
+
+
+def test_bad_id(client):
+    response = client.put("api/v1/source/new", json={"bad": "json"})
+    assert response.status_code == 422
+
+    # with pytest.raises(ValidationError):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -26,3 +26,71 @@ async def test_add_and_retrieve(database_async_sesionmaker):
 
     async with database_async_sesionmaker() as session:
         await core.delete_source(id, session=session)
+
+
+@pytest.mark.asyncio
+async def test_box(database_async_sesionmaker):
+    async with database_async_sesionmaker() as session:
+        id1 = (await core.create_source(0.0, 0.0, session=session)).id
+        id2 = (await core.create_source(1.0, 1.0, session=session)).id
+
+    # Test we recover both sources
+    async with database_async_sesionmaker() as session:
+        source_list = await core.get_box(-1, 2, -1, 2, session=session)
+
+        id_list = []
+        for source in source_list:
+            id_list.append(source.id)
+
+        assert id1 in id_list
+        assert id2 in id_list
+
+    # Test we don't recover source not in box
+    async with database_async_sesionmaker() as session:
+        source_list = await core.get_box(-1, 0.5, -1, 0.5, session=session)
+
+        id_list = []
+        for source in source_list:
+            id_list.append(source.id)
+
+        assert id1 in id_list
+        assert id2 not in id_list
+
+    # Not sure if this cleanup is needed
+    async with database_async_sesionmaker() as session:
+        await core.delete_source(id1, session=session)
+        await core.delete_source(id2, session=session)
+
+
+@pytest.mark.asyncio
+async def test_update(database_async_sesionmaker):
+    async with database_async_sesionmaker() as session:
+        id = (await core.create_source(0.0, 0.0, session=session)).id
+
+    async with database_async_sesionmaker() as session:
+        source = await core.update_source(id, 1.0, 1.0, session=session)
+
+    assert source.id == id
+    assert source.ra == 1.0
+    assert source.dec == 1.0
+
+    # Not sure if this cleanup is needed
+    async with database_async_sesionmaker() as session:
+        await core.delete_source(id, session=session)
+
+
+@pytest.mark.asyncio
+async def test_bad_id(database_async_sesionmaker):
+    with pytest.raises(ValueError):
+        async with database_async_sesionmaker() as session:
+            await core.get_source(
+                999999, session=session
+            )  # I suppose this isn't stictly safe if you have a test catalog with 1M entries
+
+    with pytest.raises(ValueError):
+        async with database_async_sesionmaker() as session:
+            await core.update_source(999999, 1.0, 1.0, session=session)
+
+    with pytest.raises(ValueError):
+        async with database_async_sesionmaker() as session:
+            await core.delete_source(999999, session=session)

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -1,9 +1,4 @@
-from socat.client import mock
-
-mock_client = mock.Client()
-
-
-def test_add_and_remove():
+def test_add_and_remove(mock_client):
     source = mock_client.create(ra=0.0, dec=0.0)
     assert source.id == 0
     assert source.ra == 0.0
@@ -19,12 +14,12 @@ def test_add_and_remove():
     mock_client.delete_source(id=0)
 
 
-def test_bad_id():
+def test_bad_id(mock_client):
     source = mock_client.update_source(id=999999, ra=1.0, dec=1.0)
     assert source is None
 
 
-def test_box():
+def test_box(mock_client):
     source = mock_client.create(ra=0.0, dec=0.0)
     id1 = source.id
     source = mock_client.create(ra=1.0, dec=1.0)

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -1,0 +1,49 @@
+from socat.client import mock
+
+mock_client = mock.Client()
+
+
+def test_add_and_remove():
+    source = mock_client.create(ra=0.0, dec=0.0)
+    assert source.id == 0
+    assert source.ra == 0.0
+    assert source.dec == 0.0
+
+    source = mock_client.get_source(id=source.id)
+
+    source = mock_client.update_source(id=source.id, ra=1.0, dec=1.0)
+    source = mock_client.get_source(id=source.id)
+    assert source.ra == 1.0
+    assert source.dec == 1.0
+
+    mock_client.delete_source(id=0)
+
+
+def test_bad_id():
+    source = mock_client.update_source(id=999999, ra=1.0, dec=1.0)
+    assert source is None
+
+
+def test_box():
+    source = mock_client.create(ra=0.0, dec=0.0)
+    id1 = source.id
+    source = mock_client.create(ra=1.0, dec=1.0)
+    id2 = source.id
+
+    sources = mock_client.get_box(ra_min=-1.0, ra_max=1.0, dec_min=-1.0, dec_max=1.0)
+
+    id_list = []
+    for source in sources:
+        id_list.append(source.id)
+
+    assert id1 in id_list
+    assert id2 in id_list
+
+    sources = mock_client.get_box(ra_min=-1.0, ra_max=0.0, dec_min=-1.0, dec_max=0.0)
+
+    id_list = []
+    for source in sources:
+        id_list.append(source.id)
+
+    assert id1 in id_list
+    assert id2 not in id_list


### PR DESCRIPTION
Still missing some coverage. In `api` both `lifespan` and the `HTTPExepction` in create source are uncovered despite seemingly having tests that cover them. `socat/client/core` has the `return` no coverage issue.