### PR TITLE
Adds settings for the client, allowing it to be (de)serialized.

### DIFF
--- a/socat/client/settings.py
+++ b/socat/client/settings.py
@@ -1,0 +1,42 @@
+"""
+Client connection settings for socat.
+"""
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from typing import Literal
+from pathlib import Path
+import pickle
+
+
+class SOCatClientSettings(BaseSettings):
+    client_type: Literal["http", "pickle"] = "pickle"
+
+    # Pickle
+    pickle_path: Path | None = None
+    "The serialized mock client for socat."
+
+    # HTTP
+    hostname: str | None = None
+    token_tag: str | None = "socat"
+    identity_server: str | None = None
+
+    model_config: SettingsConfigDict = {
+        "env_prefix": "socat_client_"
+    }
+
+    def _pickle_client(self):
+        with open(self.pickle_path, "rb") as handle:
+            client = pickle.load(handle)
+        return client
+
+    def _http_client(self):
+        raise NotImplementedError
+
+    @property
+    def client(self):
+        if self.client_type == "pickle":
+            return self._pickle_client()
+        else:
+            raise NotImplementedError(
+                "Only the pickle client works with the settings functionality"
+            )


### PR DESCRIPTION
We need a way to swap between the 'mock' client and the http version when it's ready. This implements pydantic settings using an adapter pattern to provide the appropriate client.

This also allows us to use serialized mock clients as 'real' socat clients in the future, streamlining some stuff in sotrp.