### PR TITLE
feat: updating ids to UUIDs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "astropydantic",
     "pandas",
     "pyarrow",
+    "uuid7-standard",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ exclude=["*alembic*"]
 
 [project]
 name = "socat"
-version = "0.0.2"
+version = "0.0.3"
 requires-python = ">=3.11"
 dependencies = [
     "sqlmodel",

--- a/socat/alembic/versions/35a6a33e0a34_initial_database.py
+++ b/socat/alembic/versions/35a6a33e0a34_initial_database.py
@@ -21,7 +21,7 @@ depends_on: str | Sequence[str] | None = None
 def upgrade() -> None:
     op.create_table(
         "fixed_sources",
-        sa.Column("source_id", sa.Integer, primary_key=True),
+        sa.Column("source_id", sa.Uuid, primary_key=True),
         sa.Column("ra_deg", sa.Float, nullable=False),
         sa.Column("dec_deg", sa.Float, nullable=False),
         sa.Column("flux_mJy", sa.Float, nullable=True),
@@ -30,24 +30,24 @@ def upgrade() -> None:
 
     op.create_table(
         "astroquery_services",
-        sa.Column("service_id", sa.Integer, primary_key=True),
+        sa.Column("service_id", sa.Uuid, primary_key=True),
         sa.Column("name", sa.String, nullable=False),
         sa.Column("config", sa.JSON, nullable=False),
     )
 
     op.create_table(
         "solarsystem_objects",
-        sa.Column("sso_id", sa.Integer, primary_key=True),
+        sa.Column("sso_id", sa.Uuid, primary_key=True),
         sa.Column("MPC_id", sa.Integer, index=True, nullable=True, unique=True),
         sa.Column("name", sa.String, index=True, nullable=False, unique=True),
     )
 
     op.create_table(
         "moving_sources",
-        sa.Column("ephem_id", sa.Integer, primary_key=True),
+        sa.Column("ephem_id", sa.Uuid, primary_key=True),
         sa.Column(
             "sso_id",
-            sa.Integer,
+            sa.Uuid,
             sa.ForeignKey(
                 "solarsystem_objects.sso_id", ondelete="CASCADE", onupdate="CASCADE"
             ),

--- a/socat/api/routers/fixed_sources.py
+++ b/socat/api/routers/fixed_sources.py
@@ -3,6 +3,7 @@ The web API to access the socat fixed source database.
 """
 
 import astropy.units as u
+import uuid7 as uuid
 from astropy.coordinates import ICRS
 from astropydantic import AstroPydanticICRS, AstroPydanticQuantity
 from fastapi import APIRouter, HTTPException, status
@@ -257,14 +258,14 @@ async def get_box_fixed(
 
 @router.get("/source/{source_id}")
 async def get_source(
-    source_id: int, session: SessionDependency
+    source_id: uuid.UUID, session: SessionDependency
 ) -> RegisteredFixedSource:
     """
     Get a source by id from the database
 
     Parameters
     ----------
-    source_id : int
+    source_id : uuid.UUID
         ID of source to querry
     session : SessionDependency
         Asynchronous session to use
@@ -289,14 +290,14 @@ async def get_source(
 
 @router.post("/source/{source_id}")
 async def update_source(
-    source_id: int, model: SourceModificationRequest, session: SessionDependency
+    source_id: uuid.UUID, model: SourceModificationRequest, session: SessionDependency
 ) -> RegisteredFixedSource:
     """
     Update source parameters by id
 
     Parameters
     ----------
-    source_id : int
+    source_id : uuid.UUID
         ID of source to update
     model : SourceModificationRequest
         Parameters of model to modify
@@ -324,13 +325,13 @@ async def update_source(
 
 
 @router.delete("/source/{source_id}")
-async def delete_source(source_id: int, session: SessionDependency) -> None:
+async def delete_source(source_id: uuid.UUID, session: SessionDependency) -> None:
     """
     Delete a source by id
 
     Parameters
     ----------
-    source_id : int
+    source_id : uuid.UUID
         ID of source to delete
     session : SessionDependency
         Asynchronous session to use

--- a/socat/api/routers/moving_sources.py
+++ b/socat/api/routers/moving_sources.py
@@ -3,6 +3,7 @@ The web API to access the socat moving source database.
 """
 
 import astropy.units as u
+import uuid7 as uuid
 from astropydantic import AstroPydanticICRS, AstroPydanticQuantity, AstroPydanticTime
 from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel, ValidationError
@@ -21,7 +22,7 @@ class EphemModificationRequest(BaseModel):
 
     Attributes
     ----------
-    sso_id : int | None
+    sso_id : uuid.UUID | None
         Internal SO identifier of solar system source
     MPC_id : int | None
         MPC ID of source
@@ -35,7 +36,7 @@ class EphemModificationRequest(BaseModel):
         Flux of source at ephem point in mJy
     """
 
-    sso_id: int | None
+    sso_id: uuid.UUID | None
     MPC_id: int | None
     name: str | None
     time: AstroPydanticTime | None
@@ -90,14 +91,14 @@ async def create_ephem(
 
 @router.get("/ephem/{ephem_id}")
 async def get_ephem(
-    ephem_id: int, session: SessionDependency
+    ephem_id: uuid.UUID, session: SessionDependency
 ) -> RegisteredMovingSource:
     """
     Get an ephem point by id from the database
 
     Parameters
     ----------
-    ephem_id : int
+    ephem_id : uuid.UUID
         ID of ephemeris point to querry
     session : SessionDependency
         Asynchronous session to use
@@ -122,14 +123,14 @@ async def get_ephem(
 
 @router.post("/ephem/{ephem_id}")
 async def update_ephem(
-    ephem_id: int, model: EphemModificationRequest, session: SessionDependency
+    ephem_id: uuid.UUID, model: EphemModificationRequest, session: SessionDependency
 ) -> RegisteredMovingSource:
     """
     Update an ephem point by id
 
     Parameters
     ----------
-    ephem_id : int
+    ephem_id : uuid.UUID
         ID of ephem point to update
     model : EphemModificationRequest
         Parameters of model to modify
@@ -164,13 +165,13 @@ async def update_ephem(
 
 
 @router.delete("/ephem/{ephem_id}")
-async def delete_ephem(ephem_id: int, session: SessionDependency) -> None:
+async def delete_ephem(ephem_id: uuid.UUID, session: SessionDependency) -> None:
     """
     Delete a ephem point by id
 
     Parameters
     ----------
-    ephem_id : int
+    ephem_id : uuid.UUID
         ID of ephem point to delete
     session : SessionDependency
         Asynchronous session to use

--- a/socat/api/routers/services.py
+++ b/socat/api/routers/services.py
@@ -4,6 +4,7 @@ The web API to access the socat fixed source database.
 
 from typing import Any
 
+import uuid7 as uuid
 from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel, ValidationError
 
@@ -68,13 +69,15 @@ async def create_service(
 
 
 @router.get("/service/{service_id}")
-async def get_service(service_id: int, session: SessionDependency) -> AstroqueryService:
+async def get_service(
+    service_id: uuid.UUID, session: SessionDependency
+) -> AstroqueryService:
     """
     Get a astroquery service by id from the database
 
     Parameters
     ----------
-    service_id : int
+    service_id : uuid.UUID
         ID of service to querry
     session : SessionDependency
         Asynchronous session to use
@@ -130,15 +133,17 @@ async def get_service_name(
 
 @router.post("/service/{service_id}")
 async def update_service(
-    service_id: int, model: ServiceModificationRequestion, session: SessionDependency
+    service_id: uuid.UUID,
+    model: ServiceModificationRequestion,
+    session: SessionDependency,
 ) -> AstroqueryService:
     """
     Update astroquery service parameters by id
 
     Parameters
     ----------
-    service_name : int
-        Name of source to update
+    service_id : uuid.UUID
+        ID of service to update
     model : ServiceModificationRequestion
         Parameters of service to modify
     session : SessionDependency
@@ -152,7 +157,7 @@ async def update_service(
     Raises
     ------
     HTTPException
-        If id does not correspond to any source
+        If id does not correspond to any service
     """
     try:
         response = await core.update_service(
@@ -165,13 +170,13 @@ async def update_service(
 
 
 @router.delete("/service/{service_id}")
-async def delete_service(service_id: int, session: SessionDependency) -> None:
+async def delete_service(service_id: uuid.UUID, session: SessionDependency) -> None:
     """
     Delete a astroquery service by id
 
     Parameters
     ----------
-    service_id : int
+    service_id : uuid.UUID
         ID of astroquery service to delete
     session : SessionDependency
         Asynchronous session to use

--- a/socat/api/routers/sso.py
+++ b/socat/api/routers/sso.py
@@ -2,6 +2,7 @@
 The web API to access the socat moving source database.
 """
 
+import uuid7 as uuid
 from astropydantic import AstroPydanticICRS, AstroPydanticTime
 from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel, ValidationError
@@ -94,13 +95,13 @@ async def create_sso(
 
 
 @router.get("/sso/{sso_id}")
-async def get_sso(sso_id: int, session: SessionDependency) -> SolarSystemObject:
+async def get_sso(sso_id: uuid.UUID, session: SessionDependency) -> SolarSystemObject:
     """
     Get a solar sytem source by id from the database
 
     Parameters
     ----------
-    sso_id : int
+    sso_id : uuid.UUID
         ID of solar system source to querry
     session : SessionDependency
         Asynchronous session to use
@@ -174,7 +175,7 @@ async def get_box_sso(
 
 @router.post("/sso/{sso_id}")
 async def update_sso(
-    sso_id: int,
+    sso_id: uuid.UUID,
     model: SolarSystemObjectRequest,
     session: SessionDependency,
 ) -> SolarSystemObject:
@@ -183,7 +184,7 @@ async def update_sso(
 
     Parameters
     ----------
-    sso_id : int
+    sso_id : uuid.UUID
         ID of solar system source to update
     model : SolarSystemObjectRequest
         Parameters of model to modify
@@ -214,13 +215,13 @@ async def update_sso(
 
 
 @router.delete("/sso/{sso_id}")
-async def delete_sso(sso_id: int, session: SessionDependency) -> None:
+async def delete_sso(sso_id: uuid.UUID, session: SessionDependency) -> None:
     """
     Delete a solar system source by id
 
     Parameters
     ----------
-    sso_id : int
+    sso_id : uuid.UUID
         ID of solar system source to delete
     session : SessionDependency
         Asynchronous session to use

--- a/socat/client/core.py
+++ b/socat/client/core.py
@@ -7,6 +7,7 @@ client.
 from abc import ABC, abstractmethod
 from typing import Any
 
+import uuid7 as uuid
 from astropy.coordinates import ICRS
 from astropy.time import Time
 from astropy.units import Quantity
@@ -52,7 +53,7 @@ class ClientBase(ABC):
         return []  # pragma: no cover
 
     @abstractmethod
-    def get_source(self, *, source_id: int) -> RegisteredFixedSource | None:
+    def get_source(self, *, source_id: uuid.UUID) -> RegisteredFixedSource | None:
         """
         Get information about a specific source. If the source is not found, we return None.
         """
@@ -71,7 +72,7 @@ class ClientBase(ABC):
     def update_source(
         self,
         *,
-        source_id: int,
+        source_id: uuid.UUID,
         position: ICRS | None = None,
         name: str | None = None,
         flux: Quantity | None = None,
@@ -82,7 +83,7 @@ class ClientBase(ABC):
         return None  # pragma: no cover
 
     @abstractmethod
-    def delete_source(self, *, source_id: int) -> None:
+    def delete_source(self, *, source_id: uuid.UUID) -> None:
         """
         Delete a source from the catalog.
         """
@@ -96,7 +97,7 @@ class ClientBase(ABC):
         return  # pragma: no cover
 
     @abstractmethod
-    def get_service(self, *, service_id: int) -> AstroqueryService | None:
+    def get_service(self, *, service_id: uuid.UUID) -> AstroqueryService | None:
         """
         Get information about a specific service. If the service is not found, we return None.
         """
@@ -113,7 +114,7 @@ class ClientBase(ABC):
     def update_service(
         self,
         *,
-        service_id: int,
+        service_id: uuid.UUID,
         name: str | None = None,
         config: dict[str, Any] | None = None,
     ) -> AstroqueryService | None:
@@ -123,7 +124,7 @@ class ClientBase(ABC):
         return None  # pragma: no cover
 
     @abstractmethod
-    def delete_service(self, *, service_id: int) -> None:
+    def delete_service(self, *, service_id: uuid.UUID) -> None:
         """
         Delete a service from the catalog.
         """
@@ -133,7 +134,7 @@ class ClientBase(ABC):
     def create_ephem(
         self,
         *,
-        sso_id: int,
+        sso_id: uuid.UUID,
         MPC_id: int | None,
         name: str,
         time: Time,
@@ -146,7 +147,7 @@ class ClientBase(ABC):
         return []  # pragma: no cover
 
     @abstractmethod
-    def get_ephem(self, *, ephem_id: int) -> RegisteredMovingSource | None:
+    def get_ephem(self, *, ephem_id: uuid.UUID) -> RegisteredMovingSource | None:
         """
         Get a single ephem point.
         """
@@ -156,7 +157,7 @@ class ClientBase(ABC):
     def get_ephem_points(
         self,
         *,
-        sso_id: int,
+        sso_id: uuid.UUID,
         t_min: Time,
         t_max: Time,
     ) -> list[RegisteredMovingSource] | None:
@@ -169,8 +170,8 @@ class ClientBase(ABC):
     def update_ephem(
         self,
         *,
-        ephem_id: int,
-        sso_id: int | None,
+        ephem_id: uuid.UUID,
+        sso_id: uuid.UUID | None,
         MPC_id: int | None,
         name: str | None,
         time: Time | None,
@@ -183,7 +184,7 @@ class ClientBase(ABC):
         return []  # pragma: no cover
 
     @abstractmethod
-    def delete_ephem(self, *, ephem_id: int) -> None:
+    def delete_ephem(self, *, ephem_id: uuid.UUID) -> None:
         """
         Delete a single ephem point.
         """
@@ -197,7 +198,7 @@ class ClientBase(ABC):
         return  # pragma: no cover
 
     @abstractmethod
-    def get_sso(self, *, sso_id: int) -> SolarSystemObject | None:
+    def get_sso(self, *, sso_id: uuid.UUID) -> SolarSystemObject | None:
         """
         Get information about a specific solar system source. If the service is not found, we return None.
         """
@@ -247,7 +248,7 @@ class ClientBase(ABC):
 
     @abstractmethod
     def update_sso(
-        self, *, sso_id: int, name: str | None, MPC_id: int | None
+        self, *, sso_id: uuid.UUID, name: str | None, MPC_id: int | None
     ) -> SolarSystemObject | None:
         """
         Update information about a solar system source.
@@ -255,7 +256,7 @@ class ClientBase(ABC):
         return []  #  pragma: no cover
 
     @abstractmethod
-    def delete_sso(self, *, sso_id: int) -> None:
+    def delete_sso(self, *, sso_id: uuid.UUID) -> None:
         """
         Delete solar system source.
         """
@@ -284,7 +285,7 @@ class AstroqueryClientBase(ABC):
         return  # pragma: no cover
 
     @abstractmethod
-    def get_service(self, *, service_id: int) -> AstroqueryService | None:
+    def get_service(self, *, service_id: uuid.UUID) -> AstroqueryService | None:
         """
         Get information about a specific service. If the service is not found, we return None.
         """
@@ -301,7 +302,7 @@ class AstroqueryClientBase(ABC):
     def update_service(
         self,
         *,
-        service_id: int,
+        service_id: uuid.UUID,
         name: str | None = None,
         config: dict[str, Any] | None = None,
     ) -> AstroqueryService | None:
@@ -311,7 +312,7 @@ class AstroqueryClientBase(ABC):
         return None  # pragma: no cover
 
     @abstractmethod
-    def delete_service(self, *, service_id: int) -> None:
+    def delete_service(self, *, service_id: uuid.UUID) -> None:
         """
         Delete a service from the catalog.
         """
@@ -323,7 +324,7 @@ class EphemClientBase(ABC):
     def create_ephem(
         self,
         *,
-        sso_id: int,
+        sso_id: uuid.UUID,
         MPC_id: int | None,
         name: str,
         time: Time,
@@ -336,7 +337,7 @@ class EphemClientBase(ABC):
         return []  # pragma: no cover
 
     @abstractmethod
-    def get_ephem(self, *, ephem_id: int) -> RegisteredMovingSource | None:
+    def get_ephem(self, *, ephem_id: uuid.UUID) -> RegisteredMovingSource | None:
         """
         Get a single ephem point.
         """
@@ -346,7 +347,7 @@ class EphemClientBase(ABC):
     def get_ephem_points(
         self,
         *,
-        sso_id: int,
+        sso_id: uuid.UUID,
         t_min: Time,
         t_max: Time,
     ) -> list[RegisteredMovingSource] | None:
@@ -359,8 +360,8 @@ class EphemClientBase(ABC):
     def update_ephem(
         self,
         *,
-        ephem_id: int,
-        sso_id: int | None,
+        ephem_id: uuid.UUID,
+        sso_id: uuid.UUID | None,
         MPC_id: int | None,
         name: str | None,
         time: Time | None,
@@ -373,7 +374,7 @@ class EphemClientBase(ABC):
         return []  # pragma: no cover
 
     @abstractmethod
-    def delete_ephem(self, *, ephem_id: int) -> None:
+    def delete_ephem(self, *, ephem_id: uuid.UUID) -> None:
         """
         Delete a single ephem point.
         """
@@ -389,7 +390,7 @@ class SolarSystemClientBase(ABC):
         return  # pragma: no cover
 
     @abstractmethod
-    def get_sso(self, *, sso_id: int) -> SolarSystemObject | None:
+    def get_sso(self, *, sso_id: uuid.UUID) -> SolarSystemObject | None:
         """
         Get information about a specific solar system source. If the service is not found, we return None.
         """
@@ -411,7 +412,7 @@ class SolarSystemClientBase(ABC):
 
     @abstractmethod
     def update_sso(
-        self, *, sso_id: int, name: str | None, MPC_id: int | None
+        self, *, sso_id: uuid.UUID, name: str | None, MPC_id: int | None
     ) -> SolarSystemObject | None:
         """
         Update information about a solar system source.
@@ -419,7 +420,7 @@ class SolarSystemClientBase(ABC):
         return []  #  pragma: no cover
 
     @abstractmethod
-    def delete_sso(self, *, sso_id: int) -> None:
+    def delete_sso(self, *, sso_id: uuid.UUID) -> None:
         """
         Delete solar system source.
         """

--- a/socat/client/db.py
+++ b/socat/client/db.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from contextlib import AbstractContextManager
 from typing import Any
 
+import uuid7 as uuid
 from astropy.coordinates import ICRS
 from astropy.time import Time
 from astropy.units import Quantity
@@ -108,7 +109,7 @@ class Client(ClientBase):
 
             return [s.to_model() for s in sources.scalars().all()]
 
-    def get_source(self, *, source_id: int) -> RegisteredFixedSource | None:
+    def get_source(self, *, source_id: uuid.UUID) -> RegisteredFixedSource | None:
         with self._get_session() as session:
             source = session.get(RegisteredFixedSourceTable, source_id)
             if source is None:
@@ -127,7 +128,7 @@ class Client(ClientBase):
     def update_source(
         self,
         *,
-        source_id: int,
+        source_id: uuid.UUID,
         position: ICRS | None = None,
         name: str | None = None,
         flux: Quantity | None = None,
@@ -154,7 +155,7 @@ class Client(ClientBase):
 
             return model
 
-    def delete_source(self, *, source_id: int) -> None:
+    def delete_source(self, *, source_id: uuid.UUID) -> None:
         with self._get_session() as session:
             source = session.get(RegisteredFixedSourceTable, source_id)
             if source is None:
@@ -166,7 +167,7 @@ class Client(ClientBase):
     def create_service(self, *, name: str, config: dict[str, Any]) -> AstroqueryService:
         return self._astroquery.create_service(name=name, config=config)
 
-    def get_service(self, *, service_id: int) -> AstroqueryService | None:
+    def get_service(self, *, service_id: uuid.UUID) -> AstroqueryService | None:
         return self._astroquery.get_service(service_id=service_id)
 
     def get_service_name(self, *, name: str) -> list[AstroqueryService] | None:
@@ -175,7 +176,7 @@ class Client(ClientBase):
     def update_service(
         self,
         *,
-        service_id: int,
+        service_id: uuid.UUID,
         name: str | None,
         config: dict[str, Any] | None,
     ) -> AstroqueryService | None:
@@ -183,13 +184,13 @@ class Client(ClientBase):
             service_id=service_id, name=name, config=config
         )
 
-    def delete_service(self, *, service_id: int) -> None:
+    def delete_service(self, *, service_id: uuid.UUID) -> None:
         return self._astroquery.delete_service(service_id=service_id)
 
     def create_ephem(
         self,
         *,
-        sso_id: int,
+        sso_id: uuid.UUID,
         MPC_id: int | None,
         name: str,
         time: Time,
@@ -205,13 +206,13 @@ class Client(ClientBase):
             flux=flux,
         )
 
-    def get_ephem(self, *, ephem_id: int) -> RegisteredMovingSource | None:
+    def get_ephem(self, *, ephem_id: uuid.UUID) -> RegisteredMovingSource | None:
         return self._ephem.get_ephem(ephem_id=ephem_id)
 
     def get_ephem_points(
         self,
         *,
-        sso_id: int,
+        sso_id: uuid.UUID,
         t_min: Time,
         t_max: Time,
     ) -> list[RegisteredMovingSource] | None:
@@ -220,8 +221,8 @@ class Client(ClientBase):
     def update_ephem(
         self,
         *,
-        ephem_id: int,
-        sso_id: int | None,
+        ephem_id: uuid.UUID,
+        sso_id: uuid.UUID | None,
         MPC_id: int | None,
         name: str | None,
         time: Time | None,
@@ -238,13 +239,13 @@ class Client(ClientBase):
             flux=flux,
         )
 
-    def delete_ephem(self, *, ephem_id: int) -> None:
+    def delete_ephem(self, *, ephem_id: uuid.UUID) -> None:
         return self._ephem.delete_ephem(ephem_id=ephem_id)
 
     def create_sso(self, *, name: str, MPC_id: int | None) -> SolarSystemObject:
         return self._sso.create_sso(name=name, MPC_id=MPC_id)
 
-    def get_sso(self, *, sso_id: int) -> SolarSystemObject | None:
+    def get_sso(self, *, sso_id: uuid.UUID) -> SolarSystemObject | None:
         return self._sso.get_sso(sso_id=sso_id)
 
     def get_box_sso(
@@ -302,11 +303,11 @@ class Client(ClientBase):
         return self._sso.get_sso_MPC_id(MPC_id=MPC_id)
 
     def update_sso(
-        self, *, sso_id: int, name: str | None, MPC_id: int | None
+        self, *, sso_id: uuid.UUID, name: str | None, MPC_id: int | None
     ) -> SolarSystemObject | None:
         return self._sso.update_sso(sso_id=sso_id, name=name, MPC_id=MPC_id)
 
-    def delete_sso(self, *, sso_id: int) -> None:
+    def delete_sso(self, *, sso_id: uuid.UUID) -> None:
         return self._sso.delete_sso(sso_id=sso_id)
 
     def get_source_generator(
@@ -374,7 +375,7 @@ class AstorqueryClient(AstroqueryClientBase):
 
             return service.to_model()
 
-    def get_service(self, *, service_id: int) -> AstroqueryService | None:
+    def get_service(self, *, service_id: uuid.UUID) -> AstroqueryService | None:
         with self._get_session() as session:
             service = session.get(AstroqueryServiceTable, service_id)
 
@@ -400,7 +401,7 @@ class AstorqueryClient(AstroqueryClientBase):
     def update_service(
         self,
         *,
-        service_id: int,
+        service_id: uuid.UUID,
         name: str | None,
         config: dict[str, Any] | None,
     ) -> AstroqueryService | None:
@@ -420,7 +421,7 @@ class AstorqueryClient(AstroqueryClientBase):
 
             return model
 
-    def delete_service(self, *, service_id: int) -> None:
+    def delete_service(self, *, service_id: uuid.UUID) -> None:
         with self._get_session() as session:
             service = session.get(AstroqueryServiceTable, service_id)
             if service is None:
@@ -453,7 +454,7 @@ class EphemClient(EphemClientBase):
     def create_ephem(
         self,
         *,
-        sso_id: int,
+        sso_id: uuid.UUID,
         MPC_id: int | None,
         name: str,
         time: Time,
@@ -479,7 +480,7 @@ class EphemClient(EphemClientBase):
 
             return ephem.to_model()
 
-    def get_ephem(self, *, ephem_id: int) -> RegisteredMovingSource | None:
+    def get_ephem(self, *, ephem_id: uuid.UUID) -> RegisteredMovingSource | None:
         with self._get_session() as session:
             ephem = session.get(RegisteredMovingSourceTable, ephem_id)
 
@@ -491,7 +492,7 @@ class EphemClient(EphemClientBase):
     def get_ephem_points(
         self,
         *,
-        sso_id: int,
+        sso_id: uuid.UUID,
         t_min: Time,
         t_max: Time,
     ) -> list[RegisteredMovingSource]:
@@ -505,8 +506,8 @@ class EphemClient(EphemClientBase):
     def update_ephem(
         self,
         *,
-        ephem_id: int,
-        sso_id: int | None,
+        ephem_id: uuid.UUID,
+        sso_id: uuid.UUID | None,
         MPC_id: int | None,
         name: str | None,
         time: Time | None,
@@ -537,7 +538,7 @@ class EphemClient(EphemClientBase):
 
         return model
 
-    def delete_ephem(self, *, ephem_id: int) -> None:
+    def delete_ephem(self, *, ephem_id: uuid.UUID) -> None:
         with self._get_session() as session:
             ephem = session.get(RegisteredMovingSourceTable, ephem_id)
             if ephem is None:
@@ -581,7 +582,7 @@ class SolarSystemClient(SolarSystemClientBase):
 
             return source.to_model()
 
-    def get_sso(self, *, sso_id: int) -> SolarSystemObject | None:
+    def get_sso(self, *, sso_id: uuid.UUID) -> SolarSystemObject | None:
         with self._get_session() as session:
             source = session.get(SolarSystemObjectTable, sso_id)
 
@@ -619,7 +620,7 @@ class SolarSystemClient(SolarSystemClientBase):
             return source_list
 
     def update_sso(
-        self, *, sso_id: int, name: str | None, MPC_id: int | None
+        self, *, sso_id: uuid.UUID, name: str | None, MPC_id: int | None
     ) -> SolarSystemObject | None:
         with self._get_session() as session:
             session.execute(
@@ -636,7 +637,7 @@ class SolarSystemClient(SolarSystemClientBase):
 
         return model
 
-    def delete_sso(self, *, sso_id: int) -> None:
+    def delete_sso(self, *, sso_id: uuid.UUID) -> None:
         with self._get_session() as session:
             source = session.get(SolarSystemObjectTable, sso_id)
             if source is None:

--- a/socat/client/mock.py
+++ b/socat/client/mock.py
@@ -6,6 +6,7 @@ from importlib import import_module
 from typing import Any
 
 import astropy.units as u
+import uuid7 as uuid
 from astropy.coordinates import ICRS
 from astropy.time import Time
 from astropy.units import Quantity
@@ -44,17 +45,17 @@ class Client(ClientBase):
         Create a source and add it to the catalog
     create_name(self, *, name: str, service_name: str)
         Create a source by name using astroquery and add it to the catalog
-    get_box(self, *, lower_left: ICRS, upper_right: IRCS)
+    get_box(self, *, lower_left: ICRS, upper_right: ICRS)
         Get sources within box
-    get_source(self, *, source_id: int)
+    get_source(self, *, source_id: uuid.UUID)
         Get a source by source_id
-    update_source(self, *, source_id: int, position: ICRS | None = None, name: str | None = None, flux: Quantity | None = None)
+    update_source(self, *, source_id: uuid.UUID, position: ICRS | None = None, name: str | None = None, flux: Quantity | None = None)
         Update source by source_id
-    delete_source(self, *, source_id: int)
+    delete_source(self, *, source_id: uuid.UUID)
         Delete source by source_id
     """
 
-    catalog: dict[int, RegisteredFixedSource]
+    catalog: dict[uuid.UUID, RegisteredFixedSource]
     n: int
 
     def __init__(self):
@@ -90,12 +91,12 @@ class Client(ClientBase):
         if flux is not None:
             flux = flux.to(u.mJy)
         source = RegisteredFixedSource(
-            source_id=self.n,
+            source_id=uuid.create(),
             position=position,
             flux=flux,
             name=name,
         )
-        self.catalog[self.n] = source
+        self.catalog[source.source_id] = source
         self.n += 1
 
         return source
@@ -151,12 +152,12 @@ class Client(ClientBase):
         if flux is not None:  # pragma: no cover
             flux *= u.mJy
         source = RegisteredFixedSource(
-            source_id=self.n,
+            source_id=uuid.create(),
             position=position,
             name=name,
             flux=flux,
         )
-        self.catalog[self.n] = source
+        self.catalog[source.source_id] = source
         self.n += 1
 
         return source
@@ -196,13 +197,13 @@ class Client(ClientBase):
 
         return list(sources)
 
-    def get_source(self, *, source_id: int) -> RegisteredFixedSource | None:
+    def get_source(self, *, source_id: uuid.UUID) -> RegisteredFixedSource | None:
         """
         Get source by id
 
         Parameters
         ----------
-        source_id : int
+        source_id : uuid.UUID
             ID of source of interest
 
 
@@ -275,13 +276,13 @@ class Client(ClientBase):
 
         return new
 
-    def delete_source(self, *, source_id: int):
+    def delete_source(self, *, source_id: uuid.UUID):
         """
         Delete source by id
 
         Parameters
         ----------
-        source_id : int
+        source_id : uuid.UUID
             ID of source to be deleted
 
         Returns
@@ -384,7 +385,7 @@ class Client(ClientBase):
     def create_ephem(
         self,
         *,
-        sso_id: int,
+        sso_id: uuid.UUID,
         MPC_id: int,
         name: str,
         time: Time,
@@ -396,7 +397,7 @@ class Client(ClientBase):
 
         Parameters
         ----------
-        sso_id : int
+        sso_id : uuid.UUID
             Internal SO ID of associated SSO (sso_id).
         MPC_id : int
             Minor Planet Center ID of SSO.
@@ -423,14 +424,14 @@ class Client(ClientBase):
             flux=flux,
         )
 
-    def get_ephem(self, *, ephem_id: int) -> RegisteredMovingSource | None:
+    def get_ephem(self, *, ephem_id: uuid.UUID) -> RegisteredMovingSource | None:
         """
         Get an ephem point by ID.
         Returns None if ephem not found.
 
         Parameters
         ----------
-        ephem_id : int
+        ephem_id : uuid.UUID
             Internal SO ID of ephem point.
 
         Returns
@@ -441,14 +442,14 @@ class Client(ClientBase):
         return self._ephem.get_ephem(ephem_id=ephem_id)
 
     def get_ephem_points(
-        self, *, sso_id: int, t_min: Time, t_max: Time
+        self, *, sso_id: uuid.UUID, t_min: Time, t_max: Time
     ) -> list[RegisteredMovingSource]:
         """
         Get all ephem points for a given source in a given time range.
 
         Parameters
         ----------
-        sso_id : int
+        sso_id : uuid.UUID
             Internal SO ID of source for which to get ephemeris points
         t_min : Time
             Minimum time
@@ -466,8 +467,8 @@ class Client(ClientBase):
     def update_ephem(
         self,
         *,
-        ephem_id: int,
-        sso_id: int | None,
+        ephem_id: uuid.UUID,
+        sso_id: uuid.UUID | None,
         MPC_id: int | None,
         name: str | None,
         time: Time | None,
@@ -480,9 +481,9 @@ class Client(ClientBase):
 
         Parameters
         ----------
-        ephem_id : int
+        ephem_id : uuid.UUID
             Internal SO ID of ephem point.
-        sso_id : int
+        sso_id : uuid.UUID | None
             Internal SO ID of associated SSO.
         MPC_id : int
             Minor Planet Center ID of associated SSO.
@@ -508,13 +509,13 @@ class Client(ClientBase):
             flux=flux,
         )
 
-    def delete_ephem(self, *, ephem_id: int) -> None:
+    def delete_ephem(self, *, ephem_id: uuid.UUID) -> None:
         """
         Delete an ephem point by ID.
 
         Parameters
         ----------
-        ephem_id : int
+        ephem_id : uuid.UUID
             Internal SO ID of ephem point.
 
         Returns
@@ -541,13 +542,13 @@ class Client(ClientBase):
         """
         return self._sso.create_sso(name=name, MPC_id=MPC_id)
 
-    def get_sso(self, *, sso_id: int) -> SolarSystemObject | None:
+    def get_sso(self, *, sso_id: uuid.UUID) -> SolarSystemObject | None:
         """
         Get a solar system source.
 
         Parameters
         ----------
-        sso_id : int
+        sso_id : uuid.UUID
             Internal SO ID of solar system source
 
         Returns
@@ -681,7 +682,7 @@ class Client(ClientBase):
         return self._sso.get_sso_MPC_id(MPC_id=MPC_id)
 
     def update_sso(
-        self, *, sso_id: int, name: str | None, MPC_id: int | None
+        self, *, sso_id: uuid.UUID, name: str | None, MPC_id: int | None
     ) -> SolarSystemObject | None:
         """
         Update a solar system source by ID.
@@ -689,7 +690,7 @@ class Client(ClientBase):
 
         Parameters
         ----------
-        sso_id : int
+        sso_id : uuid.UUID
             Internal SO ID of solar system source
         name : str | None
             Name of source
@@ -703,13 +704,13 @@ class Client(ClientBase):
         """
         return self._sso.update_sso(sso_id=sso_id, name=name, MPC_id=MPC_id)
 
-    def delete_sso(self, *, sso_id: int):
+    def delete_sso(self, *, sso_id: uuid.UUID):
         """
         Delete a solar system source by ID.
 
         Parameters
         ----------
-        sso_id : int
+        sso_id : uuid.UUID
             Internal SO ID of solar system source
 
         Returns
@@ -769,7 +770,7 @@ class AstroqueryClient(AstroqueryClientBase):
 
     """
 
-    catalog: dict[int, AstroqueryService]
+    catalog: dict[uuid.UUID, AstroqueryService]
     n: int
 
     def __init__(self):
@@ -795,19 +796,19 @@ class AstroqueryClient(AstroqueryClientBase):
         service : AstroqueryService
             Astroquery service that was added
         """
-        service = AstroqueryService(service_id=self.n, name=name, config=config)
-        self.catalog[self.n] = service
+        service = AstroqueryService(service_id=uuid.create(), name=name, config=config)
+        self.catalog[service.service_id] = service
         self.n += 1
 
         return service
 
-    def get_service(self, *, service_id: int) -> AstroqueryService | None:
+    def get_service(self, *, service_id: uuid.UUID) -> AstroqueryService | None:
         """
         Get a service by id number
 
         Parameters
         ----------
-        service_id : int
+        service_id : uuid.UUID
             ID of service to get
 
         Returns
@@ -843,14 +844,14 @@ class AstroqueryClient(AstroqueryClientBase):
         return service
 
     def update_service(
-        self, *, service_id: int, name: str | None, config: dict[str, Any] | None
+        self, *, service_id: uuid.UUID, name: str | None, config: dict[str, Any] | None
     ) -> AstroqueryService:
         """
         Update a service by id
 
         Parameters
         ----------
-        service_id : int
+        service_id : uuid.UUID
             ID of service to be updated
         name : str | None, Default: None
             Name of source
@@ -877,13 +878,13 @@ class AstroqueryClient(AstroqueryClientBase):
 
         return new
 
-    def delete_service(self, *, service_id: int):
+    def delete_service(self, *, service_id: uuid.UUID):
         """
         Delete service by id
 
         Parameters
         ----------
-        service_id : int
+        service_id : uuid.UUID
             ID of service to be deleted
 
         Returns
@@ -901,26 +902,26 @@ class EphemClient(EphemClientBase):
 
     Attributes
     ----------
-    catalog : dict[int, SolarSystemObject]
+    catalog : dict[uuid.UUID, SolarSystemObject]
         Dictionary of solar system sources replicating a catalog
     n : int
         Number of entries in catalog
 
     Methods
     -------
-    create_ephem(self,*,sso_id: int,MPC_id: int | None,name: str,time: Time,position: ICRS,flux: Quantity | None = None,)
+    create_ephem(self,*,sso_id: uuid.UUID,MPC_id: int | None,name: str,time: Time,position: ICRS,flux: Quantity | None = None,)
         Create a single ephemera point for solar system source.
-    get_ephem(self, *, ephem_id: int)
+    get_ephem(self, *, ephem_id: uuid.UUID)
         Get a single ephem point.
-    get_ephem_points(self, *, sso_id: int, t_min: Time, t_max: Time)
+    get_ephem_points(self, *, sso_id: uuid.UUID, t_min: Time, t_max: Time)
         Get all ephem points for a given source in a given time range. Note this takes sso_id instead of passing a SolarSystemObject.
-    update_ephem(self,*,ephem_id: int,sso_id: int | None,MPC_id: int | None,name: str | None,time: Time | None,position: ICRS | None,flux: Quantity | None,)
+    update_ephem(self,*,ephem_id: uuid.UUID,sso_id: uuid.UUID | None,MPC_id: int | None,name: str | None,time: Time | None,position: ICRS | None,flux: Quantity | None,)
         Update a single ephem point.
-    delete_ephem(self, *, ephem_id: int)
+    delete_ephem(self, *, ephem_id: uuid.UUID)
         Delete a single ephem point.
     """
 
-    catalog: dict[int, AstroqueryService]
+    catalog: dict[uuid.UUID, AstroqueryService]
     n: int
 
     def __init__(self):
@@ -933,7 +934,7 @@ class EphemClient(EphemClientBase):
     def create_ephem(
         self,
         *,
-        sso_id: int,
+        sso_id: uuid.UUID,
         MPC_id: int,
         name: str,
         time: Time,
@@ -945,7 +946,7 @@ class EphemClient(EphemClientBase):
 
         Parameters
         ----------
-        sso_id : int
+        sso_id : uuid.UUID
             Internal SO ID of associated SSO (sso_id).
         MPC_id : int
             Minor Planet Center ID of SSO.
@@ -964,7 +965,7 @@ class EphemClient(EphemClientBase):
             Ephemeris point that was added.
         """
         ephem = RegisteredMovingSource(
-            ephem_id=self.n,
+            ephem_id=uuid.create(),
             sso_id=sso_id,
             MPC_id=MPC_id,
             name=name,
@@ -972,19 +973,19 @@ class EphemClient(EphemClientBase):
             position=position,
             flux=flux,
         )
-        self.catalog[self.n] = ephem
+        self.catalog[ephem.ephem_id] = ephem
         self.n += 1
 
         return ephem
 
-    def get_ephem(self, *, ephem_id: int) -> RegisteredMovingSource | None:
+    def get_ephem(self, *, ephem_id: uuid.UUID) -> RegisteredMovingSource | None:
         """
         Get an ephem point by ID.
         Returns None if ephem not found.
 
         Parameters
         ----------
-        ephem_id : int
+        ephem_id : uuid.UUID
             Internal SO ID of ephem point.
 
         Returns
@@ -996,14 +997,14 @@ class EphemClient(EphemClientBase):
         return self.catalog.get(ephem_id, None)
 
     def get_ephem_points(
-        self, *, sso_id: int, t_min: Time, t_max: Time
+        self, *, sso_id: uuid.UUID, t_min: Time, t_max: Time
     ) -> list[RegisteredMovingSource]:
         """
         Get all ephem points for a given source in a given time range.
 
         Parameters
         ----------
-        sso_id : int
+        sso_id : uuid.UUID
             Internal SO ID of source for which to get ephemeris points
         t_min : Time
             Minimum time
@@ -1025,8 +1026,8 @@ class EphemClient(EphemClientBase):
     def update_ephem(
         self,
         *,
-        ephem_id: int,
-        sso_id: int | None,
+        ephem_id: uuid.UUID,
+        sso_id: uuid.UUID | None,
         MPC_id: int | None,
         name: str | None,
         time: Time | None,
@@ -1039,15 +1040,15 @@ class EphemClient(EphemClientBase):
 
         Parameters
         ----------
-        ephem_id : int
+        ephem_id : uuid.UUID
             Internal SO ID of ephem point.
-        sso_id : int
+        sso_id : uuid.UUID | None
             Internal SO ID of associated SSO.
-        MPC_id : int
+        MPC_id : int | None
             Minor Planet Center ID of associated SSO.
-        name : str
+        name : str | None
             Name of associated SSO.
-        time : Time
+        time : Time | None
             Time of ephem.
         flux : Quantity | None, default=None
             Flux at ephemeris.
@@ -1076,13 +1077,13 @@ class EphemClient(EphemClientBase):
 
         return new
 
-    def delete_ephem(self, *, ephem_id: int) -> None:
+    def delete_ephem(self, *, ephem_id: uuid.UUID) -> None:
         """
         Delete an ephem point by ID.
 
         Parameters
         ----------
-        ephem_id : int
+        ephem_id : uuid.UUID
             Internal SO ID of ephem point.
 
         Returns
@@ -1109,15 +1110,15 @@ class SolarSystemClient(SolarSystemClientBase):
     -------
     create_sso(self, *, name: str, MPC_id: int | None)
         Create a solar system source.
-    get_sso(self, *, sso_id: int)
+    get_sso(self, *, sso_id: uuid.UUID)
         Get a solar system source.
     get_sso_name(self, *, name: str)
         Get a solar system source by name.
     get_sso_MPC_id(self, *, MPC_id: int)
         Get a solar system source by MPC ID.
-    update_sso(self, *, sso_id: int, name: str | None, MPC_id: int | None)
+    update_sso(self, *, sso_id: uuid.UUID, name: str | None, MPC_id: int | None)
         Update a solar system source.
-    delete_sso(sefl, *, sso_id: int)
+    delete_sso(self, *, sso_id: uuid.UUID)
         Delete a solar system source.
     """
 
@@ -1147,19 +1148,19 @@ class SolarSystemClient(SolarSystemClientBase):
         solar_source : SolarSystemObject
             Solar system source that was added.
         """
-        solar_source = SolarSystemObject(sso_id=self.n, name=name, MPC_id=MPC_id)
-        self.catalog[self.n] = solar_source
+        solar_source = SolarSystemObject(sso_id=uuid.create(), name=name, MPC_id=MPC_id)
+        self.catalog[solar_source.sso_id] = solar_source
         self.n += 1
 
         return solar_source
 
-    def get_sso(self, *, sso_id: int) -> SolarSystemObject | None:
+    def get_sso(self, *, sso_id: uuid.UUID) -> SolarSystemObject | None:
         """
         Get a solar system source.
 
         Parameters
         ----------
-        sso_id : int
+        sso_id : uuid.UUID
             Internal SO ID of solar system source
 
         Returns
@@ -1216,7 +1217,7 @@ class SolarSystemClient(SolarSystemClientBase):
         return solars
 
     def update_sso(
-        self, *, sso_id: int, name: str | None, MPC_id: int | None
+        self, *, sso_id: uuid.UUID, name: str | None, MPC_id: int | None
     ) -> SolarSystemObject | None:
         """
         Update a solar system source by ID.
@@ -1224,7 +1225,7 @@ class SolarSystemClient(SolarSystemClientBase):
 
         Parameters
         ----------
-        sso_id : int
+        sso_id : uuid.UUID
             Internal SO ID of solar system source
         name : str | None
             Name of source
@@ -1251,13 +1252,13 @@ class SolarSystemClient(SolarSystemClientBase):
 
         return new
 
-    def delete_sso(self, *, sso_id: int) -> None:
+    def delete_sso(self, *, sso_id: uuid.UUID) -> None:
         """
         Delete solar system source by ID.
 
         Parameters:
         -----------
-        sso_id : int
+        sso_id : uuid.UUID
             Internal SO ID of source
 
         Returns

--- a/socat/core/fixed_sources.py
+++ b/socat/core/fixed_sources.py
@@ -2,6 +2,7 @@
 Core functionality providing access to the fixed sourcedatabase.
 """
 
+import uuid7 as uuid
 from astropy.coordinates import ICRS
 from astropy.units import Quantity
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -51,20 +52,22 @@ async def create_source(
     return source.to_model()
 
 
-async def get_source(source_id: int, session: AsyncSession) -> RegisteredFixedSource:
+async def get_source(
+    source_id: uuid.UUID, session: AsyncSession
+) -> RegisteredFixedSource:
     """
     Get a source from the database.
 
     Parameters
     ----------
-    source_id : int
+    source_id : uuid.UUID
         ID of source of interest
     session : AsyncSession
         Asynchronous session to use
 
     Returns
     -------
-    source.to_mode() : RegisteredFixedSource
+    source.to_model() : RegisteredFixedSource
         Source that has been created
 
     Raises
@@ -113,7 +116,7 @@ async def get_box_fixed(
 
 
 async def update_source(
-    source_id: int,
+    source_id: uuid.UUID,
     position: ICRS | None,
     session: AsyncSession,
     flux: Quantity | None = None,
@@ -124,6 +127,8 @@ async def update_source(
 
     Parameters
     ----------
+    source_id : uuid.UUID
+        ID of source to update
     position : ICRS | None
         Position of source in ICRS coordinates
     flux : Quanity | None
@@ -166,13 +171,13 @@ async def update_source(
     return model
 
 
-async def delete_source(source_id: int, session: AsyncSession) -> None:
+async def delete_source(source_id: uuid.UUID, session: AsyncSession) -> None:
     """
     Delete a source from the database.
 
     Parameters
     ----------
-    id : int
+    source_id : uuid.UUID
         ID of source to delete
     session : AsyncSession
         Asynchronous session to use

--- a/socat/core/moving_sources.py
+++ b/socat/core/moving_sources.py
@@ -2,6 +2,7 @@
 Core functionality providing access to the moving source ephem database.
 """
 
+import uuid7 as uuid
 from astropy.coordinates import ICRS
 from astropy.time import Time
 from astropy.units import Quantity
@@ -18,7 +19,7 @@ from socat.database import (
 
 async def create_ephem(
     session: AsyncSession,
-    sso_id: int,
+    sso_id: uuid.UUID,
     MPC_id: int | None,
     name: str,
     time: Time,
@@ -32,7 +33,7 @@ async def create_ephem(
     ----------
     session : AsyncSession
         Session to use
-    sso_id :int
+    sso_id : uuid.UUID
         Internal SO ID of source
     MPC_id : int | None
         MPC ID of source
@@ -70,13 +71,15 @@ async def create_ephem(
     return ephem.to_model()
 
 
-async def get_ephem(ephem_id: int, session: AsyncSession) -> RegisteredMovingSource:
+async def get_ephem(
+    ephem_id: uuid.UUID, session: AsyncSession
+) -> RegisteredMovingSource:
     """
     Get a solar system ephemeris point from the database.
 
     Parameters
     ----------
-    ephem_id : int
+    ephem_id : uuid.UUID
         ID of solar system ephemeris point
     session : AsyncSession
         Asynchronous session to use
@@ -129,14 +132,14 @@ async def get_ephem_points(
 
 
 async def get_ephem_by_sso_id(
-    sso_id: int, session: AsyncSession
+    sso_id: uuid.UUID, session: AsyncSession
 ) -> list[RegisteredMovingSource]:
     """
     Get all solar system ephemeris points for a given source.
 
     Parameters
     ----------
-    sso_id : int
+    sso_id : uuid.UUID
         Internal ID of source for which to get ephemeris points
     session : AsyncSession
         Asynchronous session to use
@@ -157,9 +160,9 @@ async def get_ephem_by_sso_id(
 
 
 async def update_ephem(
-    ephem_id: int,
+    ephem_id: uuid.UUID,
     session: AsyncSession,
-    sso_id: int | None,
+    sso_id: uuid.UUID | None,
     MPC_id: int | None,
     name: str | None,
     time: Time | None,
@@ -171,11 +174,11 @@ async def update_ephem(
 
     Parameters
     ----------
-    ephem_id : int
+    ephem_id : uuid.UUID
         ID of ephem.
     session : AsyncSession
         Session to use
-    sso_id :int | None
+    sso_id : uuid.UUID | None
         Internal SO ID of source
     MPC_id : int | None
         MPC ID of source
@@ -223,14 +226,14 @@ async def update_ephem(
     return model
 
 
-async def delete_ephem(ephem_id: int, session: AsyncSession) -> None:
+async def delete_ephem(ephem_id: uuid.UUID, session: AsyncSession) -> None:
     """
     Delete a solar system ephemeris point from the dattabase.
 
     Parameters
     ----------
-    ephem_id : int
-        ID of sephem pointource
+    ephem_id : uuid.UUID
+        ID of ephemeris point to delete
     session : AsyncSession
         Asynchronous session to use
 

--- a/socat/core/services.py
+++ b/socat/core/services.py
@@ -4,6 +4,7 @@ Core functionality providing access to the services database.
 
 from typing import Any
 
+import uuid7 as uuid
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -38,13 +39,15 @@ async def create_service(
     return service.to_model()
 
 
-async def get_service(service_id: int, session: AsyncSession) -> AstroqueryService:
+async def get_service(
+    service_id: uuid.UUID, session: AsyncSession
+) -> AstroqueryService:
     """
     Get an astroquery service from the database by id.
 
     Parameters
     ----------
-    service_id :  int
+    service_id : uuid.UUID
         ID of service
     session : AsyncSession
         Asynchronous session to use
@@ -98,8 +101,8 @@ async def get_service_name(
 
     Parameters
     ----------
-    service_name :  int
-        ID of service
+    service_name : str
+        Name of service
     session : AsyncSession
         Asynchronous session to use
 
@@ -130,7 +133,7 @@ async def get_service_name(
 
 
 async def update_service(
-    service_id: int,
+    service_id: uuid.UUID,
     name: str | None,
     config: dict[str, Any] | None,
     session: AsyncSession,
@@ -140,7 +143,7 @@ async def update_service(
 
      Parameters
      ----------
-     service_name : int
+     service_id : uuid.UUID
          ID of service
      name : str | None
          Name of service
@@ -176,13 +179,13 @@ async def update_service(
     return model
 
 
-async def delete_service(service_id: int, session: AsyncSession) -> None:
+async def delete_service(service_id: uuid.UUID, session: AsyncSession) -> None:
     """
     Delete a source from the database.
 
     Parameters
     ----------
-    service_id : int
+    service_id : uuid.UUID
         ID of service
     session : AsyncSession
         Asynchronous session to use

--- a/socat/core/sso.py
+++ b/socat/core/sso.py
@@ -2,6 +2,7 @@
 Core functionality providing access to the sso database.
 """
 
+import uuid7 as uuid
 from astropy.coordinates import ICRS
 from astropy.time import Time
 from sqlalchemy import select
@@ -41,13 +42,13 @@ async def create_sso(
     return source.to_model()
 
 
-async def get_sso(sso_id: int, session: AsyncSession) -> SolarSystemObject:
+async def get_sso(sso_id: uuid.UUID, session: AsyncSession) -> SolarSystemObject:
     """
     Get a solar system source from the database by id.
 
     Parameters
     ----------
-    sso_id :  int
+    sso_id :  uuid.UUID
         ID of source
     session : AsyncSession
         Asynchronous session to use
@@ -183,7 +184,7 @@ async def get_sso_MPC_id(MPC_id: int, session: AsyncSession) -> list[SolarSystem
 
 
 async def update_sso(
-    sso_id: int,
+    sso_id: uuid.UUID,
     name: str | None,
     MPC_id: int | None,
     session: AsyncSession,
@@ -192,7 +193,7 @@ async def update_sso(
     Update a solar system source.
     Parameters
     ----------
-    sso_id : int
+    sso_id : uuid.UUID
         Internal SO source ID
     name : str
         Name of solar system source
@@ -225,13 +226,13 @@ async def update_sso(
     return source.to_model()
 
 
-async def delete_sso(sso_id: int, session: AsyncSession) -> None:
+async def delete_sso(sso_id: uuid.UUID, session: AsyncSession) -> None:
     """
     Delete a solar system source from the dattabase.
 
     Parameters
     ----------
-    sso_id : int
+    sso_id : uuid.UUID
         ID of source
     session : AsyncSession
         Asynchronous session to use

--- a/socat/database/services.py
+++ b/socat/database/services.py
@@ -4,6 +4,7 @@ Core database tables storing information about services.
 
 from typing import Any
 
+import uuid7 as uuid
 from pydantic import BaseModel, ConfigDict
 from sqlmodel import JSON, Column, Field, SQLModel
 
@@ -16,7 +17,7 @@ class AstroqueryService(BaseModel):
     """An allowable astroquery service
     Attributes
     ----------
-    service_id : int
+    service_id : uuid.UUID
         Unique service identifier
     name : str
         Name of service
@@ -24,7 +25,7 @@ class AstroqueryService(BaseModel):
         json to be deserialized to config options
     """
 
-    service_id: int
+    service_id: uuid.UUID
     name: str
     config: dict[str, Any]
 
@@ -41,13 +42,13 @@ class AstroqueryServiceTable(AstroqueryService, SQLModel, table=True):
     for responding to a query with using the `to_model` method.
     Attributes
     ----------
-    id : int
+    service_id : uuid.UUID
         Unique service identifier
     """
 
     __tablename__ = "astroquery_services"
 
-    service_id: int = Field(primary_key=True)
+    service_id: uuid.UUID = Field(default_factory=uuid.create, primary_key=True)
     name: str = Field(index=True)
     config: dict[str, Any] = Field(sa_column=Column(JSON))
 

--- a/socat/database/sources.py
+++ b/socat/database/sources.py
@@ -31,13 +31,13 @@ class RegisteredFixedSource(RegisteredSource):
 
     Attributes
     ----------
-    source_id : uuid.UUID | None, default: None
+    source_id : uuid.UUID
         Unique source identifier. Internal to SO
     name : str | None
         Name of source. Optional
     """
 
-    source_id: uuid.UUID | None = None
+    source_id: uuid.UUID
     name: str | None  # Not a foreign key
 
 

--- a/socat/database/sources.py
+++ b/socat/database/sources.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import astropy.units as u
+import uuid7 as uuid
 from astropy.coordinates import ICRS
 from astropy.time import Time
 from astropydantic import AstroPydanticICRS, AstroPydanticQuantity, AstroPydanticTime
@@ -30,13 +31,13 @@ class RegisteredFixedSource(RegisteredSource):
 
     Attributes
     ----------
-    source_id : int
+    source_id : uuid.UUID | None, default: None
         Unique source identifier. Internal to SO
     name : str | None
         Name of source. Optional
     """
 
-    source_id: int | None = None
+    source_id: uuid.UUID | None = None
     name: str | None  # Not a foreign key
 
 
@@ -52,9 +53,9 @@ class RegisteredMovingSource(RegisteredSource):
 
     Attributes
     ----------
-    ephem_id : int
+    ephem_id : uuid.UUID
         ID of ephem point.
-    sso_id :int
+    sso_id : uuid.UUID
         Internal SO ID of source
     MPC_id : int | None
         MPC ID of source
@@ -64,8 +65,8 @@ class RegisteredMovingSource(RegisteredSource):
         Name of source
     """
 
-    ephem_id: int
-    sso_id: int
+    ephem_id: uuid.UUID
+    sso_id: uuid.UUID
     MPC_id: int | None
     time: AstroPydanticTime
     name: str | None  # Foreign key to MovingSourceTable
@@ -78,7 +79,7 @@ class SolarSystemObject(BaseModel):
 
     Attributes
     ----------
-    id : int
+    id : uuid.UUID
         Internal SO ID of source
     MPC_id : int | None
         Minor Planet Center ID of ephem.
@@ -86,7 +87,7 @@ class SolarSystemObject(BaseModel):
         Name of source
     """
 
-    sso_id: int
+    sso_id: uuid.UUID
     MPC_id: int | None
     name: str
 
@@ -105,7 +106,7 @@ class RegisteredFixedSourceTable(SQLModel, table=True):
 
     __tablename__ = "fixed_sources"
 
-    source_id: int = Field(primary_key=True)
+    source_id: uuid.UUID = Field(primary_key=True, default_factory=uuid.create)
     ra_deg: float = Field(nullable=False)
     dec_deg: float = Field(nullable=False)
     flux_mJy: float | None = Field(nullable=True)
@@ -141,7 +142,7 @@ class SolarSystemObjectTable(SolarSystemObject, SQLModel, table=True):
 
     __tablename__ = "solarsystem_objects"
 
-    sso_id: int = Field(primary_key=True)
+    sso_id: uuid.UUID = Field(primary_key=True, default_factory=uuid.create)
     MPC_id: int | None = Field(index=True, nullable=True, unique=True)
     name: str = Field(index=True, nullable=False, unique=True)
 
@@ -170,8 +171,8 @@ class RegisteredMovingSourceTable(SQLModel, table=True):
 
     __tablename__ = "moving_sources"
 
-    ephem_id: int = Field(primary_key=True)
-    sso_id: int = Field(
+    ephem_id: uuid.UUID = Field(primary_key=True, default_factory=uuid.create)
+    sso_id: uuid.UUID = Field(
         foreign_key="solarsystem_objects.sso_id",
         nullable=False,
         ondelete="CASCADE",
@@ -181,7 +182,7 @@ class RegisteredMovingSourceTable(SQLModel, table=True):
         nullable=True,
         ondelete="CASCADE",
     )
-    name: int = Field(
+    name: str = Field(
         foreign_key="solarsystem_objects.name",
         nullable=False,
         ondelete="CASCADE",

--- a/socat/database/statements.py
+++ b/socat/database/statements.py
@@ -6,6 +6,7 @@ database that are anything more than simple cases.
 from importlib import import_module
 
 import astropy.units as u
+import uuid7 as uuid
 from astropy.coordinates import ICRS
 from astropy.time import Time
 from astropy.units import Quantity
@@ -227,7 +228,7 @@ def get_forced_photometry_sources(minimum_flux: Quantity) -> select:
 
 
 def update_source(
-    source_id: int,
+    source_id: uuid.UUID,
     position: ICRS | None = None,
     flux: Quantity | None = None,
     name: str | None = None,
@@ -237,7 +238,7 @@ def update_source(
 
     Parameters
     ----------
-    source_id : int
+    source_id : uuid.UUID
         ID of source to update
     position : ICRS | None
         Position of source in ICRS coordinates. Optional.
@@ -324,7 +325,7 @@ def update_service(
 
 
 def update_sso(
-    sso_id: int,
+    sso_id: uuid.UUID,
     name: str | None,
     MPC_id: int | None,
 ) -> update:
@@ -333,7 +334,7 @@ def update_sso(
 
     Parameters
     ----------
-    sso_id: int
+    sso_id: uuid.UUID
         The ID of the sso source to be updated.
     name: str
         The new name to use.
@@ -370,8 +371,8 @@ def update_sso(
 
 
 def update_ephem(
-    ephem_id: int,
-    sso_id: int | None,
+    ephem_id: uuid.UUID,
+    sso_id: uuid.UUID | None,
     MPC_id: int | None,
     name: str | None,
     time: Time | None,
@@ -383,9 +384,9 @@ def update_ephem(
 
     Parameters
     ----------
-    ephem_id : int
+    ephem_id : uuid.UUID
         The ID of the ephemeris point to be updated.
-    sso_id : int | None
+    sso_id : uuid.UUID | None
         The new SSO ID for the ephemeris point.
     MPC_id : int | None
         The new MPC ID for the ephemeris point.
@@ -434,13 +435,13 @@ def update_ephem(
         )
 
 
-def get_ephem_points(sso_id: int, t_min: Time, t_max: Time) -> select:
+def get_ephem_points(sso_id: uuid.UUID, t_min: Time, t_max: Time) -> select:
     """
     Generate a select statement to get ephemeris points for a solar system object between t_min and t_max.
 
     Parameters
     ----------
-    sso_id : int
+    sso_id : uuid.UUID
         The ID of the solar system object to get ephemeris points for.
     t_min : Time
         The minimum time for ephemeris points to return.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,6 +4,7 @@ Test the core functions
 
 import astropy.units as u
 import pytest
+import uuid7 as uuid
 from astropy.coordinates import ICRS
 
 from socat import core
@@ -154,17 +155,15 @@ async def test_update(database_async_sessionmaker):
 async def test_bad_id(database_async_sessionmaker):
     with pytest.raises(ValueError):
         async with database_async_sessionmaker() as session:
-            await core.get_source(
-                source_id=999999, session=session
-            )  # I suppose this isn't stictly safe if you have a test catalog with 1M entries
+            await core.get_source(source_id=uuid.create(), session=session)
 
     position = ICRS(1 * u.deg, 1 * u.deg)
     with pytest.raises(ValueError):
         async with database_async_sessionmaker() as session:
             await core.update_source(
-                source_id=999999, position=position, session=session
+                source_id=uuid.create(), position=position, session=session
             )
 
     with pytest.raises(ValueError):
         async with database_async_sessionmaker() as session:
-            await core.delete_source(source_id=999999, session=session)
+            await core.delete_source(source_id=uuid.create(), session=session)

--- a/tests/test_db_client.py
+++ b/tests/test_db_client.py
@@ -1,5 +1,6 @@
 import astropy.units as u
 import pytest
+import uuid7 as uuid
 from astropy.coordinates import ICRS
 from astropy.time import Time
 
@@ -104,7 +105,7 @@ def test_service_crud_and_lookup(db_client):
 
     # Check null update doesn't work
     with pytest.raises(ValueError):
-        client.update_service(service_id=999999, name=None, config=None)
+        client.update_service(service_id=uuid.create(), name=None, config=None)
 
     by_name = client.get_service_name(name="VizieR")
     assert by_name is not None
@@ -370,27 +371,27 @@ def test_not_found_behavior(db_client):
     client = db_client
 
     with pytest.raises(ValueError):
-        client.get_source(source_id=999999)
+        client.get_source(source_id=uuid.create())
 
     with pytest.raises(ValueError):
         client.update_source(
-            source_id=999999,
+            source_id=uuid.create(),
             position=ICRS(1.0 * u.deg, 1.0 * u.deg),
             name="missing",
             flux=1.0 * u.mJy,
         )
 
     with pytest.raises(ValueError):
-        client.get_service(service_id=999999)
+        client.get_service(service_id=uuid.create())
 
     with pytest.raises(ValueError):
         client.get_service_name(name="missing-service")
 
     with pytest.raises(ValueError):
-        client.update_service(service_id=999999, name="x", config={})
+        client.update_service(service_id=uuid.create(), name="x", config={})
 
     with pytest.raises(ValueError):
-        client.get_sso(sso_id=999999)
+        client.get_sso(sso_id=uuid.create())
 
     with pytest.raises(ValueError):
         client.get_sso_name(name="missing-sso")
@@ -399,15 +400,15 @@ def test_not_found_behavior(db_client):
         client.get_sso_MPC_id(MPC_id=999999)
 
     with pytest.raises(ValueError):
-        client.update_sso(sso_id=999999, name="x", MPC_id=1)
+        client.update_sso(sso_id=uuid.create(), name="x", MPC_id=1)
 
     with pytest.raises(ValueError):
-        client.get_ephem(ephem_id=999999)
+        client.get_ephem(ephem_id=uuid.create())
 
     with pytest.raises(ValueError):
         client.update_ephem(
-            ephem_id=999999,
-            sso_id=1,
+            ephem_id=uuid.create(),
+            sso_id=uuid.create(),
             MPC_id=1,
             name="x",
             time=Time("2025-01-01T00:00:00.00"),
@@ -415,10 +416,10 @@ def test_not_found_behavior(db_client):
             flux=1.0 * u.mJy,
         )
 
-    client.delete_source(source_id=999999)
-    client.delete_service(service_id=999999)
-    client.delete_sso(sso_id=999999)
-    client.delete_ephem(ephem_id=999999)
+    client.delete_source(source_id=uuid.create())
+    client.delete_service(service_id=uuid.create())
+    client.delete_sso(sso_id=uuid.create())
+    client.delete_ephem(ephem_id=uuid.create())
 
 
 def test_direct_secondary_client_backcompat(database):

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -1,5 +1,6 @@
 import astropy.units as u
 import pytest
+import uuid7 as uuid
 from astropy.coordinates import ICRS
 from astroquery.exceptions import NoResultsWarning
 
@@ -8,7 +9,6 @@ def test_add_and_remove(mock_client):
     position = ICRS(0.0 * u.deg, 0.0 * u.deg)
     flux = 1.0 * u.mJy
     source = mock_client.create_source(position=position, name="mySrc", flux=flux)
-    assert source.source_id == 0
     assert source.position.ra.value == 0.0
     assert source.position.dec.value == 0.0
     assert source.flux.value == 1.0
@@ -22,29 +22,26 @@ def test_add_and_remove(mock_client):
         source_id=source.source_id, position=position, name="mySrcUpdate", flux=flux
     )
     source = mock_client.get_source(source_id=source.source_id)
-    assert source.source_id == 0
     assert source.position.ra.value == 1.0
     assert source.position.dec.value == 1.0
     assert source.flux.value == 2.0
     assert source.name == "mySrcUpdate"
 
-    mock_client.delete_source(source_id=0)
+    mock_client.delete_source(source_id=source.source_id)
 
 
 def test_add_and_remove_by_name(mock_client):
     source = mock_client.create_name(name="m1", astroquery_service="Simbad")
-    assert source.source_id == 0
     assert source.position.ra.value == 83.6324
     assert source.position.dec.value == 22.0174
 
     mock_client.delete_source(source_id=0)
 
     source = mock_client.create_name(name="m2", astroquery_service="Simbad")
-    assert source.source_id == 0
     assert source.position.ra.value == 323.36258333333336
     assert source.position.dec.value == -0.8232499999999998
 
-    mock_client.delete_source(source_id=0)
+    mock_client.delete_source(source_id=source.source_id)
 
 
 def test_bad_create_name(mock_client):
@@ -55,7 +52,9 @@ def test_bad_create_name(mock_client):
 def test_bad_id(mock_client):
     position = ICRS(1.0 * u.deg, 1.0 * u.deg)
     flux = 2.0 * u.mJy
-    source = mock_client.update_source(source_id=999999, position=position, flux=flux)
+    source = mock_client.update_source(
+        source_id=uuid.create(), position=position, flux=flux
+    )
     assert source is None
 
 
@@ -123,7 +122,6 @@ def test_add_and_remove_astroquery(mock_client):
         name="Simbad",
         config={"name_col": "main_id", "ra_col": "ra", "dec_col": "dec"},
     )
-    assert service.service_id == 0
     assert service.name == "Simbad"
     assert service.config == {"name_col": "main_id", "ra_col": "ra", "dec_col": "dec"}
 
@@ -144,14 +142,13 @@ def test_add_and_remove_astroquery(mock_client):
 
     service_list = mock_client.get_service_name(name="VizieR")
     assert len(service_list) == 1
-    assert service_list[0].service_id == 0
 
-    mock_client.delete_service(service_id=0)
+    mock_client.delete_service(service_id=service_list[0].service_id)
 
     service_list = mock_client.get_service_name(name="NOT_A_SERVICE")
     assert service_list is None
 
     service = mock_client.update_service(
-        service_id=999999, name="FAILURE", config="FRAUD"
+        service_id=uuid.create(), name="FAILURE", config="FRAUD"
     )
     assert service is None

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -4,6 +4,7 @@ Test the solar system object functions
 
 import astropy.units as u
 import pytest
+import uuid7 as uuid
 from astropy.coordinates import ICRS
 from astropy.time import Time
 
@@ -258,7 +259,7 @@ async def test_time_box(database_async_sessionmaker):
 async def test_bad_id(database_async_sessionmaker):
     with pytest.raises(ValueError):
         async with database_async_sessionmaker() as session:
-            await core.get_sso(sso_id=999999, session=session)
+            await core.get_sso(sso_id=uuid.create(), session=session)
 
     with pytest.raises(ValueError):
         async with database_async_sessionmaker() as session:
@@ -270,12 +271,12 @@ async def test_bad_id(database_async_sessionmaker):
 
     with pytest.raises(ValueError):
         async with database_async_sessionmaker() as session:
-            await core.get_ephem(ephem_id=999999, session=session)
+            await core.get_ephem(ephem_id=uuid.create(), session=session)
 
     with pytest.raises(ValueError):
         async with database_async_sessionmaker() as session:
             await core.update_sso(
-                sso_id=999999,
+                sso_id=uuid.create(),
                 name="Davida",
                 MPC_id=511,
                 session=session,
@@ -286,9 +287,9 @@ async def test_bad_id(database_async_sessionmaker):
     with pytest.raises(ValueError):
         async with database_async_sessionmaker() as session:
             await core.update_ephem(
-                ephem_id=999999,
+                ephem_id=uuid.create(),
                 session=session,
-                sso_id=1,
+                sso_id=uuid.create(),
                 name="Davida",
                 MPC_id=511,
                 time=Time("2025-01-01T00:00:00.00"),
@@ -298,8 +299,8 @@ async def test_bad_id(database_async_sessionmaker):
 
     with pytest.raises(ValueError):
         async with database_async_sessionmaker() as session:
-            await core.delete_sso(sso_id=999999, session=session)
+            await core.delete_sso(sso_id=uuid.create(), session=session)
 
     with pytest.raises(ValueError):
         async with database_async_sessionmaker() as session:
-            await core.delete_ephem(ephem_id=999999, session=session)
+            await core.delete_ephem(ephem_id=uuid.create(), session=session)

--- a/tests/test_sso_api.py
+++ b/tests/test_sso_api.py
@@ -1,5 +1,6 @@
 import astropy.units as u
 import pytest
+import uuid7 as uuid
 from astropy.time import Time
 from httpx import HTTPStatusError
 
@@ -198,26 +199,26 @@ def test_get_box(client):
 
 def test_bad_id(client):
     with pytest.raises(HTTPStatusError):
-        response = client.get(f"api/v1/sso/{999999}")
+        response = client.get(f"api/v1/sso/{uuid.create()}")
         response.raise_for_status()
 
     with pytest.raises(HTTPStatusError):
         response = client.post(
-            f"api/v1/sso/{999999}", json={"MPC_id": 511, "name": "Davida"}
+            f"api/v1/sso/{uuid.create()}", json={"MPC_id": 511, "name": "Davida"}
         )
         response.raise_for_status()
 
     with pytest.raises(HTTPStatusError):
-        response = client.delete(f"api/v1/sso/{999999}")
+        response = client.delete(f"api/v1/sso/{uuid.create()}")
         response.raise_for_status()
 
     with pytest.raises(HTTPStatusError):
-        response = client.get(f"api/v1/ephem/{999999}")
+        response = client.get(f"api/v1/ephem/{uuid.create()}")
         response.raise_for_status()
 
     with pytest.raises(HTTPStatusError):
         response = client.post(
-            f"api/v1/ephem/{999999}",
+            f"api/v1/ephem/{uuid.create()}",
             json={
                 "sso_id": 1,
                 "MPC_id": 423,
@@ -233,5 +234,5 @@ def test_bad_id(client):
         response.raise_for_status()
 
     with pytest.raises(HTTPStatusError):
-        response = client.delete(f"api/v1/ephem/{999999}")
+        response = client.delete(f"api/v1/ephem/{uuid.create()}")
         response.raise_for_status()

--- a/tests/test_sso_mock.py
+++ b/tests/test_sso_mock.py
@@ -1,5 +1,6 @@
 import astropy.units as u
 import pytest
+import uuid7 as uuid
 from astropy.coordinates import ICRS
 from astropy.time import Time
 
@@ -9,7 +10,6 @@ from socat.client.mock import SourceGenerator
 def test_add_and_remove(mock_client):
     sso = mock_client.create_sso(name="Davida", MPC_id=511)
 
-    assert sso.sso_id == 0
     assert sso.name == "Davida"
     assert sso.MPC_id == 511
 
@@ -25,7 +25,6 @@ def test_add_and_remove(mock_client):
         flux=flux,
     )
 
-    assert ephem.ephem_id == 0
     assert ephem.sso_id == sso.sso_id
     assert ephem.MPC_id == 511
     assert ephem.name == "Davida"
@@ -36,7 +35,6 @@ def test_add_and_remove(mock_client):
 
     sso = mock_client.update_sso(sso_id=sso.sso_id, name="Diotima", MPC_id=423)
 
-    assert sso.sso_id == 0
     assert sso.name == "Diotima"
     assert sso.MPC_id == 423
 
@@ -53,7 +51,6 @@ def test_add_and_remove(mock_client):
         flux=flux,
     )
 
-    assert ephem.ephem_id == 0
     assert ephem.sso_id == sso.sso_id
     assert ephem.MPC_id == 423
     assert ephem.name == "Diotima"
@@ -66,29 +63,28 @@ def test_add_and_remove(mock_client):
     ssos = mock_client.get_sso_name(name="Diotima")
     assert len(ssos) == 1  # TODO: Should probably add a second source to the catalog
     sso = ssos[0]
-    assert sso.sso_id == 0
     assert sso.name == "Diotima"
     assert sso.MPC_id == 423
 
     sso = mock_client.get_sso_MPC_id(MPC_id=423)
     assert len(ssos) == 1  # TODO: Should probably add a second source to the catalog
     sso = ssos[0]
-    assert sso.sso_id == 0
     assert sso.name == "Diotima"
     assert sso.MPC_id == 423
 
-    mock_client.delete_sso(sso_id=0)
-    mock_client.delete_ephem(ephem_id=0)
+    mock_client.delete_sso(sso_id=sso.sso_id)
+    mock_client.delete_ephem(ephem_id=ephem.ephem_id)
 
 
 def test_get_ephem_points(mock_client):
     sso = mock_client.create_sso(name="Davida", MPC_id=511)
 
+    all_ephems = []
     for i in range(10):
         time = Time("2025-01-01T00:00:00") + i * u.h
         position = ICRS((1 + i) * u.deg, (1 + i) * u.deg)
         flux = (1 + i) * u.mJy
-        mock_client.create_ephem(
+        ephem = mock_client.create_ephem(
             sso_id=sso.sso_id,
             MPC_id=511,
             name="Davida",
@@ -96,6 +92,8 @@ def test_get_ephem_points(mock_client):
             position=position,
             flux=flux,
         )
+
+        all_ephems.append(ephem)
 
     ephems = mock_client.get_ephem_points(
         sso_id=sso.sso_id,
@@ -105,7 +103,6 @@ def test_get_ephem_points(mock_client):
 
     assert len(ephems) == 4
     for i, ephem in enumerate(ephems):
-        assert ephem.ephem_id == i + 2
         assert ephem.sso_id == sso.sso_id
         assert ephem.MPC_id == 511
         assert ephem.name == "Davida"
@@ -114,9 +111,9 @@ def test_get_ephem_points(mock_client):
         assert ephem.position.dec.value == (1 + i + 2)
         assert ephem.flux.value == (1 + i + 2)
 
-    for i in range(10):
-        mock_client.delete_ephem(ephem_id=i)
-    mock_client.delete_sso(sso_id=0)
+    for i in range(len(all_ephems)):
+        mock_client.delete_ephem(ephem_id=all_ephems[i].ephem_id)
+    mock_client.delete_sso(sso_id=sso.sso_id)
 
 
 def test_get_box(mock_client):
@@ -125,12 +122,12 @@ def test_get_box(mock_client):
     sso2 = mock_client.create_sso(name="Diotima", MPC_id=423)
     sso3 = mock_client.create_sso(name="Ceres", MPC_id=1)
 
-    mock_client.create_source(
+    source1 = mock_client.create_source(
         name="mySrc1",
         position=ICRS(1 * u.deg, 1 * u.deg),
         flux=1.0 * u.mJy,
     )
-    mock_client.create_source(
+    source2 = mock_client.create_source(
         name="mySrc2",
         position=ICRS(4 * u.deg, 4 * u.deg),
         flux=2.0 * u.mJy,
@@ -211,11 +208,11 @@ def test_get_box(mock_client):
 
     for i in range(30):
         mock_client.delete_ephem(ephem_id=i)
-    mock_client.delete_sso(sso_id=0)
-    mock_client.delete_sso(sso_id=1)
-    mock_client.delete_sso(sso_id=2)
-    mock_client.delete_source(source_id=0)
-    mock_client.delete_source(source_id=1)
+    mock_client.delete_sso(sso_id=sso1.sso_id)
+    mock_client.delete_sso(sso_id=sso2.sso_id)
+    mock_client.delete_sso(sso_id=sso3.sso_id)
+    mock_client.delete_source(source_id=source1.source_id)
+    mock_client.delete_source(source_id=source2.source_id)
 
 
 def test_get_box_sso(mock_client):
@@ -284,17 +281,21 @@ def test_get_box_sso(mock_client):
     assert ssos[0].name == "Davida"
     assert ssos[0].MPC_id == 511
 
+    mock_client.delete_sso(sso_id=sso1.sso_id)
+    mock_client.delete_sso(sso_id=sso2.sso_id)
+    mock_client.delete_sso(sso_id=sso3.sso_id)
+
 
 def test_bad_id(mock_client):
-    sso = mock_client.update_sso(sso_id=999999, name="Davida", MPC_id=411)
+    sso = mock_client.update_sso(sso_id=uuid.create(), name="Davida", MPC_id=411)
     assert sso is None
 
     position = ICRS(1.0 * u.deg, 1.0 * u.deg)
     flux = 2.0 * u.mJy
     time = Time("2025-01-01T00:00:00")
     ephem = mock_client.update_ephem(
-        ephem_id=999999,
-        sso_id=0,
+        ephem_id=uuid.create(),
+        sso_id=uuid.create(),
         MPC_id=423,
         name="Diotima",
         time=time,


### PR DESCRIPTION
Switches all IDs to UUIDs. Note that `MPC_id`s aren't really internal IDs, they're actually the external Minor Planet Center numbering for the SSO. As such they don't get a UUID. 